### PR TITLE
Don't use HLint annotations if GHCi is unavailable.

### DIFF
--- a/src/Crypto/Nettle/CCM.hs
+++ b/src/Crypto/Nettle/CCM.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
+{-# LANGUAGE CPP, MultiParamTypeClasses, FlexibleInstances #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Crypto.Nettle.CCM
@@ -45,8 +45,10 @@ import Data.Byteable
 
 import Nettle.Utils
 
+#ifdef GHCI
 -- internal functions are not camelCase on purpose
 {-# ANN module "HLint: ignore Use camelCase" #-}
+#endif
 
 -- ccm needs a 128-bit block cipher
 

--- a/src/Crypto/Nettle/Ciphers.hs
+++ b/src/Crypto/Nettle/Ciphers.hs
@@ -72,8 +72,10 @@ import Crypto.Nettle.Ciphers.Internal
 import Crypto.Nettle.Ciphers.ForeignImports
 import Nettle.Utils
 
+#ifdef GHCI
 -- internal functions are not camelCase on purpose
 {-# ANN module "HLint: ignore Use camelCase" #-}
+#endif
 
 #define INSTANCE_CIPHER(Typ) \
 instance Cipher Typ where \

--- a/src/Crypto/Nettle/Ciphers/ForeignImports.hsc
+++ b/src/Crypto/Nettle/Ciphers/ForeignImports.hsc
@@ -102,8 +102,10 @@ module Crypto.Nettle.Ciphers.ForeignImports
 
 import Nettle.Utils
 
+#ifdef GHCI
 -- internal functions are not camelCase on purpose
 {-# ANN module "HLint: ignore Use camelCase" #-}
+#endif
 
 #include "nettle-ciphers.h"
 

--- a/src/Crypto/Nettle/Ciphers/Internal.hs
+++ b/src/Crypto/Nettle/Ciphers/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FlexibleContexts #-}
+{-# LANGUAGE CPP, MultiParamTypeClasses, FlexibleInstances, FlexibleContexts #-}
 
 module Crypto.Nettle.Ciphers.Internal
 	( NettleCipher(..)
@@ -38,8 +38,10 @@ import Data.Bits (xor)
 import Nettle.Utils
 import Crypto.Nettle.Ciphers.ForeignImports
 
+#ifdef GHCI
 -- internal functions are not camelCase on purpose
 {-# ANN module "HLint: ignore Use camelCase" #-}
+#endif
 
 class NettleCipher c where
 	-- | pointer to new context, key length, (const) key pointer

--- a/src/Crypto/Nettle/Hash.hs
+++ b/src/Crypto/Nettle/Hash.hs
@@ -68,8 +68,10 @@ import Data.SecureMem
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Internal as B
 
+#ifdef GHCI
 -- internal functions are not camelCase on purpose
 {-# ANN module "HLint: ignore Use camelCase" #-}
+#endif
 
 nettleHashBlockSize  :: NettleHashAlgorithm a => Tagged a Int
 nettleHashBlockSize = nha_block_size

--- a/src/Crypto/Nettle/Hash/ForeignImports.hsc
+++ b/src/Crypto/Nettle/Hash/ForeignImports.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE CPP, ForeignFunctionInterface #-}
 
 module Crypto.Nettle.Hash.ForeignImports
 	( NettleHashInit
@@ -134,8 +134,10 @@ module Crypto.Nettle.Hash.ForeignImports
 
 import Nettle.Utils
 
+#ifdef GHCI
 -- internal functions are not camelCase on purpose
 {-# ANN module "HLint: ignore Use camelCase" #-}
+#endif
 
 #include "nettle-hash.h"
 

--- a/src/Crypto/Nettle/UMAC.hs
+++ b/src/Crypto/Nettle/UMAC.hs
@@ -37,8 +37,10 @@ import Nettle.Utils
 import Crypto.Nettle.KeyedHash
 import Crypto.Nettle.Hash.ForeignImports
 
+#ifdef GHCI
 -- internal functions are not camelCase on purpose
 {-# ANN module "HLint: ignore Use camelCase" #-}
+#endif
 
 {-|
 'UMAC' is a class of keyed hash algorithms that take an additional nonce.

--- a/src/Tests/Ciphers.hs
+++ b/src/Tests/Ciphers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 
 import Test.Framework (defaultMain, testGroup, Test(..))
 import Test.Framework.Providers.QuickCheck2 (testProperty)
@@ -76,7 +77,9 @@ genBlockTest' = go undefined where
 			, label "ctrCombine + ctrCombine unaligned" $ (ctrCombine c iv . ctrCombine c iv) input   == input
 			]
 
+#ifdef GHCI
 {-# ANN module "HLint: ignore Reduce duplication" #-}
+#endif
 genStreamTest :: StreamCipher c => c -> Test
 genStreamTest c' = testProperty ("generated " ++ cipherName c' ++ " stream cipher test") $ do
 	c <- genCipher c'


### PR DESCRIPTION
Without this you get a "Cant do annotations without GHCi" error message from GHC on some architectures.  I've tested that this fixes the build on Ubuntu ppc64el, which currently lacks GHCi.
