### PR TITLE
Support nettle 4.0

### DIFF
--- a/nettle.cabal
+++ b/nettle.cabal
@@ -25,6 +25,10 @@ Flag UsePkgConfig
   Description: Use pkg-config to check for library dependences
   Default: True
 
+Flag Nettle4
+  Description: Use the code path for nettle 4.x
+  Default: False
+
 Library
   Default-Language:  Haskell2010
   hs-source-dirs:    src
@@ -53,6 +57,9 @@ Library
     PkgConfig-Depends: nettle
   else
     Extra-libraries: nettle
+
+  if flag(Nettle4)
+    cpp-options: -DNETTLE_VERSION_MAJOR=4
 
 Test-Suite test-ciphers
   Default-Language:  Haskell2010

--- a/src/Crypto/Nettle/Hash.hs
+++ b/src/Crypto/Nettle/Hash.hs
@@ -97,7 +97,11 @@ nettleHashFinalize c = flip witness c $ do
 	return $ unsafeDupablePerformIO $
 		B.create digestSize $ \digestptr -> do
 			_ <- withSecureMemCopy (nha_ctx c) $ \ctxptr ->
+#if (NETTLE_VERSION_MAJOR >= 4)
+				digestfun ctxptr digestptr
+#else
 				digestfun ctxptr (fromIntegral digestSize) digestptr
+#endif
 			return ()
 
 class NettleHashAlgorithm a where
@@ -274,7 +278,11 @@ instance NettleHashAlgorithm SHA3_224 where
 	nha_block_size  = Tagged c_sha3_224_block_size
 	nha_digest_size = Tagged c_sha3_224_digest_size
 	nha_name        = Tagged "SHA3-224"
+#if (NETTLE_VERSION_MAJOR >= 4)
+	nha_init        = Tagged c_sha3_init
+#else
 	nha_init        = Tagged c_sha3_224_init
+#endif
 	nha_update      = Tagged c_sha3_224_update
 	nha_digest      = Tagged c_sha3_224_digest
 	nha_ctx         = sha3_224_ctx
@@ -288,7 +296,11 @@ instance NettleHashAlgorithm SHA3_256 where
 	nha_block_size  = Tagged c_sha3_256_block_size
 	nha_digest_size = Tagged c_sha3_256_digest_size
 	nha_name        = Tagged "SHA3-256"
+#if (NETTLE_VERSION_MAJOR >= 4)
+	nha_init        = Tagged c_sha3_init
+#else
 	nha_init        = Tagged c_sha3_256_init
+#endif
 	nha_update      = Tagged c_sha3_256_update
 	nha_digest      = Tagged c_sha3_256_digest
 	nha_ctx         = sha3_256_ctx
@@ -302,7 +314,11 @@ instance NettleHashAlgorithm SHA3_384 where
 	nha_block_size  = Tagged c_sha3_384_block_size
 	nha_digest_size = Tagged c_sha3_384_digest_size
 	nha_name        = Tagged "SHA3-384"
+#if (NETTLE_VERSION_MAJOR >= 4)
+	nha_init        = Tagged c_sha3_init
+#else
 	nha_init        = Tagged c_sha3_384_init
+#endif
 	nha_update      = Tagged c_sha3_384_update
 	nha_digest      = Tagged c_sha3_384_digest
 	nha_ctx         = sha3_384_ctx
@@ -316,7 +332,11 @@ instance NettleHashAlgorithm SHA3_512 where
 	nha_block_size  = Tagged c_sha3_512_block_size
 	nha_digest_size = Tagged c_sha3_512_digest_size
 	nha_name        = Tagged "SHA3-512"
+#if (NETTLE_VERSION_MAJOR >= 4)
+	nha_init        = Tagged c_sha3_init
+#else
 	nha_init        = Tagged c_sha3_512_init
+#endif
 	nha_update      = Tagged c_sha3_512_update
 	nha_digest      = Tagged c_sha3_512_digest
 	nha_ctx         = sha3_512_ctx

--- a/src/Crypto/Nettle/UMAC.hs
+++ b/src/Crypto/Nettle/UMAC.hs
@@ -93,7 +93,7 @@ class NettleUMAC u where
 	nu_set_key :: Tagged u (Ptr Word8 -> Ptr Word8 -> IO ())
 	nu_set_nonce :: Tagged u (Ptr Word8 -> Word -> Ptr Word8 -> IO ())
 	nu_update :: Tagged u (Ptr Word8 -> Word -> Ptr Word8 -> IO ())
-	nu_digest :: Tagged u (Ptr Word8 -> Word -> Ptr Word8 -> IO ())
+	nu_digest :: Tagged u NettleHashDigest
 	nu_ctx :: u -> SecureMem
 	nu_Ctx :: SecureMem -> u
 
@@ -146,7 +146,11 @@ nettleUmacFinalize c = untag $ go c where
 			ctx' <- secureMemCopy (nu_ctx ctx)
 			dig <- withSecureMemPtr ctx' $ \ctxptr ->
 				B.create digestSize $ \digestptr ->
+#if (NETTLE_VERSION_MAJOR >= 4)
+				digest ctxptr digestptr
+#else
 				digest ctxptr (fromIntegral digestSize) digestptr
+#endif
 			return (dig, nu_Ctx ctx')
 
 #define INSTANCE_UMAC(Typ) \

--- a/src/nettle-ciphers.h
+++ b/src/nettle-ciphers.h
@@ -4,7 +4,7 @@
 
 #include <nettle/version.h>
 
-#if (NETTLE_VERSION_MAJOR != 3)
+#if (NETTLE_VERSION_MAJOR < 3 || NETTLE_VERSION_MAJOR > 4)
 #error unsupported nettle version
 #endif
 

--- a/src/nettle-hash.h
+++ b/src/nettle-hash.h
@@ -4,7 +4,7 @@
 
 #include <nettle/version.h>
 
-#if (NETTLE_VERSION_MAJOR != 3)
+#if (NETTLE_VERSION_MAJOR < 3 || NETTLE_VERSION_MAJOR > 4)
 #error unsupported nettle version
 #endif
 #if (NETTLE_VERSION_MAJOR == 3 && NETTLE_VERSION_MINOR < 2)


### PR DESCRIPTION
In nettle 4, the `sha3_*_init` functions have been replaced by a singular `sha3_init` function. In addition, the digest functions don't take the desired size as input.

The new code is gated behind CPP directives. As the `.hs` files don't have access to the `NETTLE_VERSION_MAJOR` macro, it gets simulated via a new flag `Nettle4`. If that flag is passed, the code path for nettle 4 is chosen. The flag obviously has to match the installed version of nettle. Set to false by default to maintain compatibility with previous versions of `haskell-nettle`.