### PR TITLE
feat: Modernise API based on crypton and port to ram

### DIFF
--- a/nettle.cabal
+++ b/nettle.cabal
@@ -32,12 +32,11 @@ Flag Nettle4
 Library
   Default-Language:  Haskell2010
   hs-source-dirs:    src
-  Build-Depends:     base >= 4 && < 5
+  Build-Depends:     base >= 4.9 && < 5
                    , bytestring >= 0.10.8 && < 0.13
-                   , byteable >= 0.1.1 && < 0.2
+                   , crypton >= 1.1.0 && < 1.2
+                   , ram >= 0.20.1 && < 0.23
                    , tagged >= 0.8.5 && < 0.9
-                   , securemem >= 0.1.9 && < 0.2
-                   , crypto-cipher-types >= 0.0.3 && < 0.1
   Exposed-modules:   Crypto.Nettle.ChaChaPoly1305
                      Crypto.Nettle.Ciphers
                      Crypto.Nettle.CCM
@@ -66,15 +65,25 @@ Test-Suite test-ciphers
   type:              exitcode-stdio-1.0
   hs-source-dirs:    src/Tests
   Main-Is:           Ciphers.hs
-  Build-depends:     base >= 4 && < 5
+  Build-depends:     base >= 4.9 && < 5
                    , bytestring >= 0.10.8 && < 0.13
+                   , crypton >= 1.1.0 && < 1.2
+                   , ram >= 0.20.1 && < 0.23
+                   , HUnit >= 1.6.0 && < 1.7
                    , QuickCheck >= 2 && < 3
                    , array >= 0.5.1 && < 0.6
                    , test-framework >= 0.3.3 && > 0.4
+                   , test-framework-hunit >= 0.3.0 && < 0.4
                    , test-framework-quickcheck2 >= 0.2.9
-                   , crypto-cipher-types >= 0.0.3 && < 0.1
-                   , crypto-cipher-tests >= 0.0.11 && < 0.1
                    , nettle
+  Other-modules:
+    Ciphers.KAT
+    Ciphers.PropertyTests
+    Ciphers.TestModes
+    Ciphers.Utils
+    HexUtils
+    KAT.AES
+    KAT.Utils
   ghc-options: -fno-warn-tabs
 
 Test-Suite test-hashes
@@ -82,7 +91,7 @@ Test-Suite test-hashes
   type:              exitcode-stdio-1.0
   hs-source-dirs:    src/Tests
   Main-Is:           Hash.hs
-  Build-depends:     base >= 4 && < 5
+  Build-depends:     base >= 4.9 && < 5
                    , bytestring >= 0.10.8 && < 0.13
                    , tagged >= 0.8.5 && < 0.9
                    , array >= 0.5.1 && < 0.6
@@ -90,6 +99,10 @@ Test-Suite test-hashes
                    , HUnit >= 1.6.0 && < 1.7
                    , test-framework-hunit >= 0.3.0 && < 0.4
                    , nettle
+  Other-modules:
+    HexUtils
+    TestUtils
+    VectorsHash
   ghc-options: -fno-warn-tabs
 
 Test-Suite test-hmac
@@ -97,7 +110,7 @@ Test-Suite test-hmac
   type:              exitcode-stdio-1.0
   hs-source-dirs:    src/Tests
   Main-Is:           HMAC.hs
-  Build-depends:     base >= 4 && < 5
+  Build-depends:     base >= 4.9 && < 5
                    , bytestring >= 0.10.8 && < 0.13
                    , tagged >= 0.8.5 && < 0.9
                    , array >= 0.5.1 && < 0.6
@@ -105,6 +118,10 @@ Test-Suite test-hmac
                    , HUnit >= 1.6.0 && < 1.7
                    , test-framework-hunit >= 0.3.0 && < 0.4
                    , nettle
+  Other-modules:
+    HexUtils
+    TestUtils
+    VectorsHMAC
   ghc-options: -fno-warn-tabs
 
 Test-Suite test-umac
@@ -112,7 +129,7 @@ Test-Suite test-umac
   type:              exitcode-stdio-1.0
   hs-source-dirs:    src/Tests
   Main-Is:           UMAC.hs
-  Build-depends:     base >= 4 && < 5
+  Build-depends:     base >= 4.9 && < 5
                    , bytestring >= 0.10.8 && < 0.13
                    , tagged >= 0.8.5 && < 0.9
                    , array >= 0.5.1 && < 0.6
@@ -120,6 +137,10 @@ Test-Suite test-umac
                    , HUnit >= 1.6.0 && < 1.7
                    , test-framework-hunit >= 0.3.0 && < 0.4
                    , nettle
+  Other-modules:
+    HexUtils
+    TestUtils
+    VectorsUMAC
   ghc-options: -fno-warn-tabs
 
 source-repository head

--- a/src/Crypto/Nettle/CCM.hs
+++ b/src/Crypto/Nettle/CCM.hs
@@ -38,12 +38,12 @@ module Crypto.Nettle.CCM
 	, ccmInitTLS
 	) where
 
-
-import Crypto.Cipher.Types
-import qualified Data.ByteString as B
-import Data.Byteable
+import qualified Crypto.Cipher.Types as CCT
+import Crypto.Error
+import qualified Data.ByteArray as BA
 import Data.Maybe (fromJust)
 
+import Crypto.Nettle.Ciphers.Internal
 import Nettle.Utils
 
 -- internal functions are not camelCase on purpose
@@ -51,33 +51,37 @@ import Nettle.Utils
 
 -- ccm needs a 128-bit block cipher
 
-data CCM cipher
-	= CCM_Header (Int, Int, B.ByteString) B.ByteString
-	| CCM_Enc (Int, Int, B.ByteString) B.ByteString (IV cipher) B.ByteString
-	| CCM_Dec (Int, Int, B.ByteString) B.ByteString (IV cipher) B.ByteString
+data CCM cipher message nonce
+	= CCM_Header (Int, Int, nonce) message
+	| CCM_Enc (Int, Int, nonce) message (CCT.IV cipher) message
+	| CCM_Dec (Int, Int, nonce) message (CCT.IV cipher) message
 
 {-|
 Start a CCM encryption with specified tag length @t@, length @q@ of the message length field and a @15-q@ bytes long @nonce@.
 Fails if any parameter is invalid or the block cipher doesn't use a 16-byte 'blockSize'.
 -}
 ccmInit
-	:: (BlockCipher cipher, Byteable iv)
+	:: (CCT.BlockCipher cipher, BA.ByteArrayAccess iv)
 	=> Int    -- ^ tag length @t@
 	-> Int    -- ^ length @q@ of the message length field
 	-> cipher -- ^ cipher initialized with key
 	-> iv     -- ^ @nonce@ with length @15-q@
-	-> Maybe (AEAD cipher)
-ccmInit t q cipher nonce = ccm_init t q cipher nonce >>= Just . AEAD cipher . AEADState
+	-> CryptoFailable (CCT.AEAD cipher )
+ccmInit t q cipher nonce = ccm_init t q cipher nonce >>= \state -> (CryptoPassed $ CCT.AEAD {CCT.aeadModeImpl = nettle_aead_mode_impl cipher, CCT.aeadState = state})
 
-ccm_init :: (BlockCipher cipher, Byteable iv) => Int -> Int -> cipher -> iv -> Maybe (CCM cipher)
-ccm_init t q cipher nonce = if valid then Just $ CCM_Header (t, q, toBytes nonce) B.empty else Nothing
+ccm_init :: (CCT.BlockCipher cipher, BA.ByteArrayAccess iv) => Int -> Int -> cipher -> iv -> CryptoFailable (CCM cipher BA.ScrubbedBytes BA.ScrubbedBytes)
+ccm_init t q cipher nonce = if valid then CryptoPassed $ CCM_Header (t, q, copyAndConvertToScrubbedBytes nonce) BA.empty else CryptoFailed reason
 	where
 	valid = valid_cipher && valid_t && valid_q && valid_nonce
-	valid_cipher = blockSize cipher == 16
+	valid_cipher = CCT.blockSize cipher == 16
 	valid_t = t >= 4 && t <= 16 && even t
 	valid_q = q >= 2 && q <= 8
 	nonce_len = 15 - q
-	valid_nonce = byteableLength nonce == fromIntegral nonce_len
+	valid_nonce = BA.length nonce == fromIntegral nonce_len
+	reason = if not valid_cipher then CryptoError_KeySizeInvalid
+		else if not valid_t then CryptoError_AuthenticationTagSizeInvalid
+		else if not valid_nonce then CryptoError_IvSizeInvalid
+		else CryptoError_AEADModeNotSupported
 
 {-|
 Start a CCM encryption with specified tag length @t = 16@, length @q = 3@ for the message length field and a @8@ bytes long @nonce@.
@@ -85,64 +89,79 @@ Fails if any parameter is invalid or the block cipher doesn't use a 16-byte 'blo
 This are the parameters used for TLS.
 -}
 ccmInitTLS
-	:: (BlockCipher cipher, Byteable iv)
+	:: (CCT.BlockCipher cipher, BA.ByteArrayAccess iv)
 	=> cipher -- ^ cipher initialized with key
 	-> iv     -- ^ 8 byte @nonce@
-	-> Maybe (AEAD cipher)
+	-> CryptoFailable (CCT.AEAD cipher)
 ccmInitTLS = ccmInit 16 3
 
 
-ccm_encodeAdditionalLength :: B.ByteString -> B.ByteString
-ccm_encodeAdditionalLength s = B.append (encLen $ B.length s) s where
+ccm_encodeAdditionalLength :: BA.ByteArray ba => ba -> ba
+ccm_encodeAdditionalLength s = BA.append (encLen $ BA.length s) s where
 	encLen n
-		| n == 0                       = B.empty
-		| n < (2^(16::Int)-2^(8::Int)) = B.pack $ netEncode 2 n
-		| n < (2^(32::Int))            = B.pack (0xff:0xfe:netEncode 4 n)
-		| otherwise                    = B.pack (0xff:0xff:netEncode 8 n)
+		| n == 0                       = BA.empty
+		| n < (2^(16::Int)-2^(8::Int)) = BA.pack $ netEncode 2 n
+		| n < (2^(32::Int))            = BA.pack (0xff:0xfe:netEncode 4 n)
+		| otherwise                    = BA.pack (0xff:0xff:netEncode 8 n)
 
-pad_zero :: Int -> B.ByteString -> B.ByteString
-pad_zero l s = B.append s $ B.replicate (l - 1 - (B.length s - 1) `mod` l) 0
+pad_zero :: BA.ByteArray ba => Int -> ba -> ba
+pad_zero l s = BA.append s $ BA.replicate (l - 1 - (BA.length s - 1) `mod` l) 0
 
-_makeIV :: BlockCipher cipher => B.ByteString -> IV cipher
-_makeIV = fromJust . makeIV
+_makeIV :: (CCT.BlockCipher cipher, BA.ByteArrayAccess ba) => ba -> CCT.IV cipher
+_makeIV = fromJust . CCT.makeIV
 
-ccm_start_iv :: BlockCipher cipher => (Int, Int, B.ByteString) -> IV cipher
-ccm_start_iv (_, q, nonce) = _makeIV $ B.concat [B.singleton $ fromIntegral $ q - 1, nonce, B.replicate (q - 1) 0, B.singleton 1]
+ccm_start_iv :: (CCT.BlockCipher cipher, BA.ByteArray bn) => (Int, Int, bn) -> CCT.IV cipher
+ccm_start_iv (_, q, nonce) = _makeIV $ concatToScrubbedBytes [BA.singleton $ fromIntegral $ q - 1, nonce, BA.replicate (q - 1) 0, BA.singleton 1]
 
-ccm_tag_iv :: BlockCipher cipher => (Int, Int, B.ByteString) -> IV cipher
-ccm_tag_iv (_, q, nonce) = _makeIV $ B.concat [B.singleton $ fromIntegral $ q - 1, nonce, B.replicate q 0]
+ccm_tag_iv :: (CCT.BlockCipher cipher, BA.ByteArray bn) => (Int, Int, bn) -> CCT.IV cipher
+ccm_tag_iv (_, q, nonce) = _makeIV $ concatToScrubbedBytes [BA.singleton $ fromIntegral $ q - 1, nonce, BA.replicate q 0]
 
-ccm_crypt :: BlockCipher cipher => cipher -> IV cipher -> B.ByteString -> (B.ByteString, IV cipher)
+ccm_crypt :: (CCT.BlockCipher cipher, BA.ByteArray ba) => cipher -> CCT.IV cipher -> ba -> (ba, CCT.IV cipher)
 ccm_crypt key iv src = let
-	blocks = (B.length src + 15) `div` 16
-	dst = ctrCombine key iv src
-	iv' = ivAdd iv blocks
+	blocks = (BA.length src + 15) `div` 16
+	dst = CCT.ctrCombine key iv src
+	iv' = CCT.ivAdd iv blocks
 	in (dst, iv')
 
-ccm_tag :: BlockCipher cipher => cipher -> (Int, Int, B.ByteString) -> B.ByteString -> B.ByteString -> Int -> AuthTag
+ccm_tag :: (CCT.BlockCipher cipher, BA.ByteArray ba, BA.ByteArray bn) => cipher -> (Int, Int, bn) -> ba -> ba -> Int -> CCT.AuthTag
 ccm_tag key (t, q, nonce) header msg taglen = let
 	-- 64*(header != "") + 8*M' + L'
-	auth_flags = (if B.length header > 0 then 64 else 0) + 4*(fromIntegral t - 2) + (fromIntegral q - 1)
-	b0 = B.concat [B.singleton auth_flags, nonce, B.pack $ netEncode q $ B.length msg]
-	blocks = B.concat [b0, pad_zero 16 $ ccm_encodeAdditionalLength header, pad_zero 16 msg]
-	tag = fst $ ccm_crypt key (ccm_tag_iv (t, q, nonce)) $ B.drop (B.length blocks - 16) $ cbcEncrypt key nullIV blocks
-	in AuthTag $ B.take taglen tag
+	auth_flags = (if BA.length header > 0 then 64 else 0) + 4*(fromIntegral t - 2) + (fromIntegral q - 1)
+	b0 = BA.concat [BA.singleton auth_flags, nonce, BA.pack $ netEncode q $ BA.length msg]
+	blocks = BA.concat [b0, pad_zero 16 $ ccm_encodeAdditionalLength header, pad_zero 16 msg]
+	tag = fst $ ccm_crypt key (ccm_tag_iv (t, q, nonce)) $ BA.drop (BA.length blocks - 16) $ CCT.cbcEncrypt key CCT.nullIV blocks
+	in CCT.AuthTag $ BA.take taglen tag
 
-instance BlockCipher cipher => AEADModeImpl cipher (CCM cipher) where
-	aeadStateAppendHeader _ (CCM_Header (t, q, nonce) header) src = CCM_Header (t, q, nonce) $ B.append header src
-	aeadStateAppendHeader _ _ _ = error "can't aeadStateAppendHeader anymore, already have real data"
-	aeadStateEncrypt key (CCM_Header (t, q, nonce) header) src = aeadStateEncrypt key (CCM_Enc (t, q, nonce) header iv B.empty) src
-		where iv = ccm_start_iv (t, q, nonce)
-	aeadStateEncrypt key (CCM_Enc (t, q, nonce) header iv msg) src = let
-		(dst, iv') = ccm_crypt key iv src
-		in (dst, CCM_Enc (t, q, nonce) header iv' $ B.append msg src)
-	aeadStateEncrypt _ _ _ = error "can't aeadStateEncrypt anymore, already is in decrypt mode"
-	aeadStateDecrypt key (CCM_Header (t, q, nonce) header) src = aeadStateDecrypt key (CCM_Dec (t, q, nonce) header iv B.empty) src
-		where iv = ccm_start_iv (t, q, nonce)
-	aeadStateDecrypt key (CCM_Dec (t, q, nonce) header iv msg) src = let
-		(dst, iv') = ccm_crypt key iv src
-		in (dst, CCM_Enc (t, q, nonce) header iv' $ B.append msg dst)
-	aeadStateDecrypt _ _ _ = error "can't aeadStateDecrypt anymore, already is in encrypt mode"
-	aeadStateFinalize key (CCM_Header (t, q, nonce) header      ) taglen = ccm_tag key (t, q, nonce) header B.empty taglen
-	aeadStateFinalize key (CCM_Enc    (t, q, nonce) header _ msg) taglen = ccm_tag key (t, q, nonce) header msg     taglen
-	aeadStateFinalize key (CCM_Dec    (t, q, nonce) header _ msg) taglen = ccm_tag key (t, q, nonce) header msg     taglen
+
+nettle_ccm_aeadImplAppendHeader :: (CCT.BlockCipher cipher, BA.ByteArrayAccess msg, BA.ByteArray ba) => cipher -> (CCM cipher ba ba) -> msg -> (CCM cipher ba ba)
+nettle_ccm_aeadImplAppendHeader _ (CCM_Header (t, q, nonce) header) src = CCM_Header (t, q, nonce) $ BA.append header (BA.convert src)
+nettle_ccm_aeadImplAppendHeader _ _ _ = error "can't aeadStateAppendHeader anymore, already have real data"
+
+nettle_ccm_aeadImplEncrypt :: (CCT.BlockCipher cipher, BA.ByteArray msg, BA.ByteArray ba) => cipher -> (CCM cipher ba ba) -> msg -> (msg, (CCM cipher ba ba))
+nettle_ccm_aeadImplEncrypt key (CCM_Header (t, q, nonce) header) src = nettle_ccm_aeadImplEncrypt key (CCM_Enc (t, q, nonce) header iv BA.empty) src
+			where iv = ccm_start_iv (t, q, nonce)
+nettle_ccm_aeadImplEncrypt key (CCM_Enc (t, q, nonce) header iv msg) src = let
+			(dst, iv') = ccm_crypt key iv src
+			in (dst, CCM_Enc (t, q, nonce) header iv' $ BA.append msg (BA.convert src))
+nettle_ccm_aeadImplEncrypt _ _ _ = error "can't aeadStateEncrypt anymore, already is in decrypt mode"
+
+nettle_ccm_aeadImplDecrypt :: (CCT.BlockCipher cipher, BA.ByteArray msg, BA.ByteArray ba) => cipher -> (CCM cipher ba ba) -> msg -> (msg, (CCM cipher ba ba))
+nettle_ccm_aeadImplDecrypt key (CCM_Header (t, q, nonce) header) src = nettle_ccm_aeadImplDecrypt key (CCM_Dec (t, q, nonce) header iv BA.empty) src
+			where iv = ccm_start_iv (t, q, nonce)
+nettle_ccm_aeadImplDecrypt key (CCM_Dec (t, q, nonce) header iv msg) src = let
+			(dst, iv') = ccm_crypt key iv src
+			in (dst, CCM_Enc (t, q, nonce) header iv' $ BA.append msg (BA.convert dst))
+nettle_ccm_aeadImplDecrypt _ _ _ = error "can't aeadStateDecrypt anymore, already is in encrypt mode"
+
+nettle_ccm_aeadImplFinalize :: (CCT.BlockCipher cipher, BA.ByteArray msg, BA.ByteArray nonce) => cipher -> (CCM cipher msg nonce) -> Int -> CCT.AuthTag
+nettle_ccm_aeadImplFinalize key (CCM_Header (t, q, nonce) header      ) taglen = ccm_tag key (t, q, nonce) header BA.empty taglen
+nettle_ccm_aeadImplFinalize key (CCM_Enc    (t, q, nonce) header _ msg) taglen = ccm_tag key (t, q, nonce) header msg      taglen
+nettle_ccm_aeadImplFinalize key (CCM_Dec    (t, q, nonce) header _ msg) taglen = ccm_tag key (t, q, nonce) header msg      taglen
+
+instance (CCT.BlockCipher cipher, BA.ByteArray ba) => NettleAeadModeImpl cipher (CCM cipher ba ba) where
+	nettle_aead_mode_impl c = CCT.AEADModeImpl {
+		CCT.aeadImplAppendHeader = nettle_ccm_aeadImplAppendHeader c
+		, CCT.aeadImplEncrypt = nettle_ccm_aeadImplEncrypt c
+		, CCT.aeadImplDecrypt = nettle_ccm_aeadImplDecrypt c
+		, CCT.aeadImplFinalize = nettle_ccm_aeadImplFinalize c
+	}

--- a/src/Crypto/Nettle/ChaChaPoly1305.hs
+++ b/src/Crypto/Nettle/ChaChaPoly1305.hs
@@ -28,9 +28,9 @@ module Crypto.Nettle.ChaChaPoly1305 (
 	, chaChaPoly1305Decrypt
 	) where
 
+import qualified Data.ByteArray as BA
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Internal as B
-import Data.SecureMem
 
 import Crypto.Nettle.Ciphers.ForeignImports
 import Nettle.Utils
@@ -47,16 +47,17 @@ chaChaPoly1305Encrypt
 	-> B.ByteString                 -- ^ @plain@ data to encrypt
 	-> (B.ByteString, B.ByteString) -- ^ returns (@cipher@, @tag@) ciphertext and verification tag
 chaChaPoly1305Encrypt key nonce aad plain = unsafeDupablePerformIO $ do
-	ctx <- allocateSecureMem c_chacha_poly1305_ctx_size
+	let k = copyAndConvertToScrubbedBytes key
+	    n = copyAndConvertToScrubbedBytes nonce
 	tag <- B.create 16 (\_ -> return ())
 	cipher <- B.create (B.length plain) (\_ -> return ())
-	withByteStringPtr plain $ \psize pptr ->
+	_ <- withByteStringPtr plain $ \psize pptr ->
 		withByteStringPtr aad $ \aadsize aadptr ->
 		withByteStringPtr cipher $ \_ cipherptr ->
 		withByteStringPtr tag $ \_ tagptr ->
-		withSecureMemPtr ctx $ \ctxptr ->
-		withSecureMemPtrSz (toSecureMem key) $ \ksize kptr -> if ksize /= 32 then error "Invalid key length" else
-		withSecureMemPtrSz (toSecureMem nonce) $ \nsize nptr -> if nsize /= 12 then error "Invalid nonce length" else do
+		createScrubbedBytes c_chacha_poly1305_ctx_size $ \ctxptr ->
+		BA.withByteArray k $ \kptr -> if (BA.length k) /= 32 then error "Invalid key length" else
+		BA.withByteArray n $ \nptr -> if (BA.length n) /= 12 then error "Invalid nonce length" else do
 		c_chacha_poly1305_set_key ctxptr kptr
 		c_chacha_poly1305_set_nonce ctxptr nptr
 		c_chacha_poly1305_update ctxptr aadsize aadptr
@@ -70,16 +71,17 @@ Decrypt cipher text and verify a (possible shortened) tag for the encrypted text
 -}
 chaChaPoly1305Decrypt :: B.ByteString -> B.ByteString -> B.ByteString -> B.ByteString -> B.ByteString -> Maybe B.ByteString
 chaChaPoly1305Decrypt key nonce aad cipher verifytag = unsafeDupablePerformIO $ do
-	ctx <- allocateSecureMem c_chacha_poly1305_ctx_size
+	let k = copyAndConvertToScrubbedBytes key
+	    n = copyAndConvertToScrubbedBytes nonce
 	tag <- B.create 16 (\_ -> return ())
 	plain <- B.create (B.length cipher) (\_ -> return ())
-	withByteStringPtr cipher $ \psize pptr ->
+	_ <- withByteStringPtr cipher $ \psize pptr ->
 		withByteStringPtr aad $ \aadsize aadptr ->
 		withByteStringPtr plain $ \_ plainptr ->
 		withByteStringPtr tag $ \_ tagptr ->
-		withSecureMemPtr ctx $ \ctxptr ->
-		withSecureMemPtrSz (toSecureMem key) $ \ksize kptr -> if ksize /= 32 then error "Invalid key length" else
-		withSecureMemPtrSz (toSecureMem nonce) $ \nsize nptr -> if nsize /= 12 then error "Invalid nonce length" else do
+		createScrubbedBytes c_chacha_poly1305_ctx_size $ \ctxptr ->
+		BA.withByteArray k $ \kptr -> if (BA.length k) /= 32 then error "Invalid key length" else
+		BA.withByteArray n $ \nptr -> if (BA.length n) /= 12 then error "Invalid nonce length" else do
 		c_chacha_poly1305_set_key ctxptr kptr
 		c_chacha_poly1305_set_nonce ctxptr nptr
 		c_chacha_poly1305_update ctxptr aadsize aadptr

--- a/src/Crypto/Nettle/Ciphers.hs
+++ b/src/Crypto/Nettle/Ciphers.hs
@@ -61,15 +61,15 @@ module Crypto.Nettle.Ciphers (
 	, ESTREAM_SALSA20
 	) where
 
-import Crypto.Cipher.Types
-import Crypto.Nettle.CCM
-
-import Data.SecureMem
-import qualified Data.ByteString as B
-import Data.Word (Word64)
+import qualified Crypto.Cipher.Types as CCT
+import Crypto.Error
 import Data.Bits
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as B
 import Data.Tagged
+import Data.Word (Word64)
 
+import Crypto.Nettle.CCM
 import Crypto.Nettle.Ciphers.Internal
 import Crypto.Nettle.Ciphers.ForeignImports
 import Nettle.Utils
@@ -78,14 +78,14 @@ import Nettle.Utils
 {-# ANN module "HLint: ignore Use camelCase" #-}
 
 #define INSTANCE_CIPHER(Typ) \
-instance Cipher Typ where \
+instance CCT.Cipher Typ where \
 	{ cipherInit = nettle_cipherInit \
 	; cipherName = witness nc_cipherName \
 	; cipherKeySize = witness nc_cipherKeySize \
 	}
 #define INSTANCE_BLOCKCIPHER(Typ) \
 INSTANCE_CIPHER(Typ); \
-instance BlockCipher Typ where \
+instance CCT.BlockCipher Typ where \
 	{ blockSize = witness nbc_blockSize \
 	; ecbEncrypt = nettle_ecbEncrypt \
 	; ecbDecrypt = nettle_ecbDecrypt \
@@ -94,19 +94,20 @@ instance BlockCipher Typ where \
 	; cfbEncrypt = nettle_cfbEncrypt \
 	; cfbDecrypt = nettle_cfbDecrypt \
 	; ctrCombine = nettle_ctrCombine \
-	; aeadInit AEAD_GCM = nettle_gcm_aeadInit \
-	; aeadInit AEAD_CCM = ccmInitTLS \
-	; aeadInit _        = \_ _ -> Nothing \
+	; aeadInit CCT.AEAD_GCM = nettle_gcm_aeadInit \
+	; aeadInit (CCT.AEAD_CCM 0 CCT.CCM_M16 CCT.CCM_L2) = ccmInitTLS \
+	; aeadInit _        = \_ _ -> CryptoFailed CryptoError_AEADModeNotSupported \
 	} ; \
-instance AEADModeImpl Typ NettleGCM where \
-	{ aeadStateAppendHeader = nettle_gcm_aeadStateAppendHeader \
-	; aeadStateEncrypt      = nettle_gcm_aeadStateEncrypt \
-	; aeadStateDecrypt      = nettle_gcm_aeadStateDecrypt \
-	; aeadStateFinalize     = nettle_gcm_aeadStateFinalize \
+instance NettleAeadModeImpl Typ NettleGCM where \
+	nettle_aead_mode_impl c = CCT.AEADModeImpl { \
+	  CCT.aeadImplAppendHeader = nettle_gcm_aeadStateAppendHeader c \
+	, CCT.aeadImplEncrypt      = nettle_gcm_aeadStateEncrypt c \
+	, CCT.aeadImplDecrypt      = nettle_gcm_aeadStateDecrypt c \
+	, CCT.aeadImplFinalize     = nettle_gcm_aeadStateFinalize c \
 	}
 #define INSTANCE_STREAMCIPHER(Typ) \
 INSTANCE_CIPHER(Typ); \
-instance StreamCipher Typ where \
+instance CCT.StreamCipher Typ where \
 	{ streamCombine = nettle_streamCombine \
 	}
 #define INSTANCE_STREAMNONCECIPHER(Typ) \
@@ -117,7 +118,7 @@ instance StreamNonceCipher Typ where \
 	}
 #define INSTANCE_BLOCKEDSTREAMCIPHER(Typ) \
 INSTANCE_CIPHER(Typ); \
-instance StreamCipher Typ where \
+instance CCT.StreamCipher Typ where \
 	{ streamCombine = nettle_blockedStreamCombine \
 	}
 #define INSTANCE_BLOCKEDSTREAMNONCECIPHER(Typ) \
@@ -133,11 +134,11 @@ of 128, 196 and 256 bits (16, 24 and 32 bytes). The 'blockSize' is always 128 bi
 
 'aeadInit' only supports the 'AEAD_GCM' mode for now.
 -}
-newtype AES = AES SecureMem
+newtype AES = AES BA.ScrubbedBytes
 instance NettleCipher AES where
 	nc_cipherInit    = Tagged c_hs_aes_init
 	nc_cipherName    = Tagged "AES"
-	nc_cipherKeySize = Tagged $ KeySizeEnum [16,24,32]
+	nc_cipherKeySize = Tagged $ CCT.KeySizeEnum [16,24,32]
 	nc_ctx_size      = Tagged c_hs_aes_ctx_size
 	nc_ctx   (AES c) = c
 	nc_Ctx           = AES
@@ -153,11 +154,11 @@ INSTANCE_BLOCKCIPHER(AES)
 {-|
 'AES128' provides the same interface as 'AES', but is restricted to 128-bit keys.
 -}
-newtype AES128 = AES128 SecureMem
+newtype AES128 = AES128 BA.ScrubbedBytes
 instance NettleCipher AES128 where
 	nc_cipherInit    = Tagged (\ctx _ key -> c_hs_aes128_init ctx key)
 	nc_cipherName    = Tagged "AES-128"
-	nc_cipherKeySize = Tagged $ KeySizeFixed 16
+	nc_cipherKeySize = Tagged $ CCT.KeySizeFixed 16
 	nc_ctx_size      = Tagged c_hs_aes128_ctx_size
 	nc_ctx (AES128 c) = c
 	nc_Ctx            = AES128
@@ -176,11 +177,11 @@ INSTANCE_BLOCKCIPHER(AES128)
 {-|
 'AES192' provides the same interface as 'AES', but is restricted to 192-bit keys.
 -}
-newtype AES192 = AES192 SecureMem
+newtype AES192 = AES192 BA.ScrubbedBytes
 instance NettleCipher AES192 where
 	nc_cipherInit    = Tagged (\ctx _ key -> c_hs_aes192_init ctx key)
 	nc_cipherName    = Tagged "AES-192"
-	nc_cipherKeySize = Tagged $ KeySizeFixed 24
+	nc_cipherKeySize = Tagged $ CCT.KeySizeFixed 24
 	nc_ctx_size      = Tagged c_hs_aes192_ctx_size
 	nc_ctx  (AES192 c) = c
 	nc_Ctx             = AES192
@@ -199,11 +200,11 @@ INSTANCE_BLOCKCIPHER(AES192)
 {-|
 'AES256' provides the same interface as 'AES', but is restricted to 256-bit keys.
 -}
-newtype AES256 = AES256 SecureMem
+newtype AES256 = AES256 BA.ScrubbedBytes
 instance NettleCipher AES256 where
 	nc_cipherInit    = Tagged (\ctx _ key -> c_hs_aes256_init ctx key)
 	nc_cipherName    = Tagged "AES-256"
-	nc_cipherKeySize = Tagged $ KeySizeFixed 32
+	nc_cipherKeySize = Tagged $ CCT.KeySizeFixed 32
 	nc_ctx_size      = Tagged c_hs_aes256_ctx_size
 	nc_ctx  (AES256 c) = c
 	nc_Ctx             = AES256
@@ -227,11 +228,11 @@ The default 'cipherInit' uses @ekb = bit-length of the key@; 'arctwoInitEKB' all
 
 'ARCTWO' uses keysizes from 1 to 128 bytes, and uses a 'blockSize' of 64 bits (8 bytes).
 -}
-newtype ARCTWO = ARCTWO SecureMem
+newtype ARCTWO = ARCTWO BA.ScrubbedBytes
 instance NettleCipher ARCTWO where
 	nc_cipherInit    = Tagged c_arctwo_set_key
 	nc_cipherName    = Tagged "ARCTWO"
-	nc_cipherKeySize = Tagged $ KeySizeRange 1 128
+	nc_cipherKeySize = Tagged $ CCT.KeySizeRange 1 128
 	nc_ctx_size      = Tagged c_arctwo_ctx_size
 	nc_ctx  (ARCTWO c) = c
 	nc_Ctx             = ARCTWO
@@ -245,13 +246,13 @@ INSTANCE_BLOCKCIPHER(ARCTWO)
 {-|
 Initialize cipher with an explicit @ekb@ value (valid values from 1 to 1024, 0 meaning the same as 1024).
 -}
-arctwoInitEKB :: Key ARCTWO -> Word -> ARCTWO
+arctwoInitEKB :: BA.ByteArray key => key -> Word -> CryptoFailable ARCTWO
 arctwoInitEKB k ekb = nettle_cipherInit' initfun k where
 	initfun ctxptr ksize ptr = c_arctwo_set_key_ekb ctxptr ksize ptr ekb
 {-|
 Initialize cipher with @ekb = 1024@.
 -}
-arctwoInitGutmann :: Key ARCTWO -> ARCTWO
+arctwoInitGutmann :: BA.ByteArray key => key -> CryptoFailable ARCTWO
 arctwoInitGutmann = nettle_cipherInit' c_arctwo_set_key_gutmann
 
 
@@ -259,11 +260,11 @@ arctwoInitGutmann = nettle_cipherInit' c_arctwo_set_key_gutmann
 'BLOWFISH' is a block cipher designed by Bruce Schneier.
 It uses a 'blockSize' of 64 bits (8 bytes), and a variable key size from 64 to 448 bits (8 to 56 bytes).
 -}
-newtype BLOWFISH = BLOWFISH SecureMem
+newtype BLOWFISH = BLOWFISH BA.ScrubbedBytes
 instance NettleCipher BLOWFISH where
 	nc_cipherInit    = Tagged c_blowfish_set_key
 	nc_cipherName    = Tagged "BLOWFISH"
-	nc_cipherKeySize = Tagged $ KeySizeRange 1 128
+	nc_cipherKeySize = Tagged $ CCT.KeySizeRange 1 128
 	nc_ctx_size      = Tagged c_blowfish_ctx_size
 	nc_ctx  (BLOWFISH c) = c
 	nc_Ctx             = BLOWFISH
@@ -285,11 +286,11 @@ Camellia uses a the same 'blockSize' and key sizes as 'AES'.
 
 'aeadInit' only supports the 'AEAD_GCM' mode for now.
 -}
-newtype Camellia = Camellia SecureMem
+newtype Camellia = Camellia BA.ScrubbedBytes
 instance NettleCipher Camellia where
 	nc_cipherInit    = Tagged c_hs_camellia_init
 	nc_cipherName    = Tagged "Camellia"
-	nc_cipherKeySize = Tagged $ KeySizeEnum [16,24,32]
+	nc_cipherKeySize = Tagged $ CCT.KeySizeEnum [16,24,32]
 	nc_ctx_size      = Tagged c_hs_camellia_ctx_size
 	nc_ctx     (Camellia c) = c
 	nc_Ctx             = Camellia
@@ -305,11 +306,11 @@ INSTANCE_BLOCKCIPHER(Camellia)
 {-|
 'Camellia128' provides the same interface as 'Camellia', but is restricted to 128-bit keys.
 -}
-newtype Camellia128 = Camellia128 SecureMem
+newtype Camellia128 = Camellia128 BA.ScrubbedBytes
 instance NettleCipher Camellia128 where
 	nc_cipherInit    = Tagged (\ctx _ key -> c_hs_camellia128_init ctx key)
 	nc_cipherName    = Tagged "Camellia-128"
-	nc_cipherKeySize = Tagged $ KeySizeFixed 16
+	nc_cipherKeySize = Tagged $ CCT.KeySizeFixed 16
 	nc_ctx_size      = Tagged c_hs_camellia128_ctx_size
 	nc_ctx  (Camellia128 c) = c
 	nc_Ctx             = Camellia128
@@ -327,11 +328,11 @@ INSTANCE_BLOCKCIPHER(Camellia128)
 {-|
 'Camellia192' provides the same interface as 'Camellia', but is restricted to 192-bit keys.
 -}
-newtype Camellia192 = Camellia192 SecureMem
+newtype Camellia192 = Camellia192 BA.ScrubbedBytes
 instance NettleCipher Camellia192 where
 	nc_cipherInit    = Tagged (\ctx _ key -> c_hs_camellia192_init ctx key)
 	nc_cipherName    = Tagged "Camellia-192"
-	nc_cipherKeySize = Tagged $ KeySizeFixed 24
+	nc_cipherKeySize = Tagged $ CCT.KeySizeFixed 24
 	nc_ctx_size      = Tagged c_hs_camellia192_ctx_size
 	nc_ctx  (Camellia192 c) = c
 	nc_Ctx             = Camellia192
@@ -349,11 +350,11 @@ INSTANCE_BLOCKCIPHER(Camellia192)
 {-|
 'Camellia256' provides the same interface as 'Camellia', but is restricted to 256-bit keys.
 -}
-newtype Camellia256 = Camellia256 SecureMem
+newtype Camellia256 = Camellia256 BA.ScrubbedBytes
 instance NettleCipher Camellia256 where
 	nc_cipherInit    = Tagged (\ctx _ key -> c_hs_camellia256_init ctx key)
 	nc_cipherName    = Tagged "Camellia-256"
-	nc_cipherKeySize = Tagged $ KeySizeFixed 32
+	nc_cipherKeySize = Tagged $ CCT.KeySizeFixed 32
 	nc_ctx_size      = Tagged c_hs_camellia256_ctx_size
 	nc_ctx  (Camellia256 c) = c
 	nc_Ctx             = Camellia256
@@ -372,11 +373,11 @@ INSTANCE_BLOCKCIPHER(Camellia256)
 'CAST128' is a block cipher specified in RFC 2144. It uses a 64 bit (8 bytes) 'blockSize',
 and a variable key size of 40 up to 128 bits (5 to 16 bytes).
 -}
-newtype CAST128 = CAST128 SecureMem
+newtype CAST128 = CAST128 BA.ScrubbedBytes
 instance NettleCipher CAST128 where
 	nc_cipherInit    = Tagged c_cast5_set_key
 	nc_cipherName    = Tagged "CAST-128"
-	nc_cipherKeySize = Tagged $ KeySizeRange 5 16
+	nc_cipherKeySize = Tagged $ CCT.KeySizeRange 5 16
 	nc_ctx_size      = Tagged c_cast128_ctx_size
 	nc_ctx  (CAST128 c) = c
 	nc_Ctx             = CAST128
@@ -396,11 +397,11 @@ It uses a 'blockSize' of 64 bits (8 bytes), and a key size of 56 bits.
 The key is given as 8 bytes, as one bit per byte is used as a parity bit.
 The parity bit is ignored by this implementation.
 -}
-newtype DES = DES SecureMem
+newtype DES = DES BA.ScrubbedBytes
 instance NettleCipher DES where
 	nc_cipherInit    = Tagged $ \ctxptr _ -> c_des_set_key ctxptr
 	nc_cipherName    = Tagged "DES"
-	nc_cipherKeySize = Tagged $ KeySizeFixed 8
+	nc_cipherKeySize = Tagged $ CCT.KeySizeFixed 8
 	nc_ctx_size      = Tagged c_des_ctx_size
 	nc_ctx  (DES c) = c
 	nc_Ctx             = DES
@@ -420,11 +421,11 @@ Encryption first encrypts with k1, then decrypts with k2, then encrypts with k3.
 The 'blockSize' is the same as for 'DES': 64 bits (8 bytes),
 and the keys are simply concatenated, forming a 24 byte key string (with 168 bits actually getting used).
 -}
-newtype DES_EDE3 = DES_EDE3 SecureMem
+newtype DES_EDE3 = DES_EDE3 BA.ScrubbedBytes
 instance NettleCipher DES_EDE3 where
 	nc_cipherInit    = Tagged $ \ctxptr _ -> c_des3_set_key ctxptr
 	nc_cipherName    = Tagged "DES-EDE3"
-	nc_cipherKeySize = Tagged $ KeySizeFixed 24
+	nc_cipherKeySize = Tagged $ CCT.KeySizeFixed 24
 	nc_ctx_size      = Tagged c_des3_ctx_size
 	nc_ctx  (DES_EDE3 c) = c
 	nc_Ctx             = DES_EDE3
@@ -445,11 +446,11 @@ although smaller bits are just padded with zeroes.
 
 'aeadInit' only supports the 'AEAD_GCM' mode for now.
 -}
-newtype SERPENT = SERPENT SecureMem
+newtype SERPENT = SERPENT BA.ScrubbedBytes
 instance NettleCipher SERPENT where
 	nc_cipherInit    = Tagged c_serpent_set_key
 	nc_cipherName    = Tagged "SERPENT"
-	nc_cipherKeySize = Tagged $ KeySizeRange 16 32
+	nc_cipherKeySize = Tagged $ CCT.KeySizeRange 16 32
 	nc_ctx_size      = Tagged c_serpent_ctx_size
 	nc_ctx  (SERPENT c) = c
 	nc_Ctx             = SERPENT
@@ -468,11 +469,11 @@ INSTANCE_BLOCKCIPHER(SERPENT)
 
 'aeadInit' only supports the 'AEAD_GCM' mode for now.
 -}
-newtype TWOFISH = TWOFISH SecureMem
+newtype TWOFISH = TWOFISH BA.ScrubbedBytes
 instance NettleCipher TWOFISH where
 	nc_cipherInit    = Tagged c_twofish_set_key
 	nc_cipherName    = Tagged "TWOFISH"
-	nc_cipherKeySize = Tagged $ KeySizeEnum [16,24,32]
+	nc_cipherKeySize = Tagged $ CCT.KeySizeEnum [16,24,32]
 	nc_ctx_size      = Tagged c_twofish_ctx_size
 	nc_ctx  (TWOFISH c) = c
 	nc_Ctx             = TWOFISH
@@ -490,11 +491,11 @@ INSTANCE_BLOCKCIPHER(TWOFISH)
 
 Valid key sizes are from 1 to 256 bytes.
 -}
-newtype ARCFOUR = ARCFOUR SecureMem
+newtype ARCFOUR = ARCFOUR BA.ScrubbedBytes
 instance NettleCipher ARCFOUR where
 	nc_cipherInit    = Tagged c_arcfour_set_key
 	nc_cipherName    = Tagged "ARCFOUR"
-	nc_cipherKeySize = Tagged $ KeySizeEnum [16,24,32]
+	nc_cipherKeySize = Tagged $ CCT.KeySizeEnum [16,24,32]
 	nc_ctx_size      = Tagged c_arcfour_ctx_size
 	nc_ctx  (ARCFOUR c) = c
 	nc_Ctx             = ARCFOUR
@@ -509,8 +510,8 @@ setting a nonce restarts the cipher.
 
 A good value for the nonce is a message/packet counter. Usually a nonce should not be reused with the same key.
 -}
-class StreamCipher cipher => StreamNonceCipher cipher where
-	streamNonceSize :: cipher -> KeySizeSpecifier
+class CCT.StreamCipher cipher => StreamNonceCipher cipher where
+	streamNonceSize :: cipher -> CCT.KeySizeSpecifier
 	streamSetNonce  :: cipher -> B.ByteString -> Maybe cipher
 
 word64BE :: Word64 -> B.ByteString
@@ -550,11 +551,11 @@ Don't reuse a nonce with the same key.
 
 Setting a nonce also resets the remaining padding data.
 -}
-newtype CHACHA = CHACHA (SecureMem, B.ByteString)
+newtype CHACHA = CHACHA (BA.ScrubbedBytes, B.ByteString)
 instance NettleCipher CHACHA where
 	nc_cipherInit    = Tagged wrap_chacha_set_key
 	nc_cipherName    = Tagged "ChaCha"
-	nc_cipherKeySize = Tagged $ KeySizeFixed 32
+	nc_cipherKeySize = Tagged $ CCT.KeySizeFixed 32
 	nc_ctx_size      = Tagged c_chacha_ctx_size
 	nc_ctx (CHACHA (c, _)) = c
 	nc_Ctx c           = CHACHA (c, B.empty)
@@ -563,7 +564,7 @@ instance NettleBlockedStreamCipher CHACHA where
 	nbsc_IncompleteState (CHACHA (c, _)) inc = CHACHA (c, inc)
 	nbsc_incompleteState (CHACHA (_, inc)) = inc
 	nbsc_streamCombine = Tagged c_chacha_crypt
-	nbsc_nonceSize     = Tagged $ KeySizeFixed 8
+	nbsc_nonceSize     = Tagged $ CCT.KeySizeFixed 8
 	nbsc_setNonce      = Tagged $ Just wrap_chacha_set_nonce
 INSTANCE_BLOCKEDSTREAMNONCECIPHER(CHACHA)
 
@@ -591,11 +592,11 @@ Don't reuse a nonce with the same key.
 
 Setting a nonce also resets the remaining padding data.
 -}
-newtype SALSA20 = SALSA20 (SecureMem, B.ByteString)
+newtype SALSA20 = SALSA20 (BA.ScrubbedBytes, B.ByteString)
 instance NettleCipher SALSA20 where
 	nc_cipherInit    = Tagged wrap_salsa20_set_key
 	nc_cipherName    = Tagged "Salsa20"
-	nc_cipherKeySize = Tagged $ KeySizeEnum [16,32]
+	nc_cipherKeySize = Tagged $ CCT.KeySizeEnum [16,32]
 	nc_ctx_size      = Tagged c_salsa20_ctx_size
 	nc_ctx (SALSA20 (c, _)) = c
 	nc_Ctx c           = SALSA20 (c, B.empty)
@@ -604,7 +605,7 @@ instance NettleBlockedStreamCipher SALSA20 where
 	nbsc_IncompleteState (SALSA20 (c, _)) inc = SALSA20 (c, inc)
 	nbsc_incompleteState (SALSA20 (_, inc)) = inc
 	nbsc_streamCombine = Tagged c_salsa20_crypt
-	nbsc_nonceSize     = Tagged $ KeySizeFixed 8
+	nbsc_nonceSize     = Tagged $ CCT.KeySizeFixed 8
 	nbsc_setNonce      = Tagged $ Just wrap_salsa20_set_nonce
 INSTANCE_BLOCKEDSTREAMNONCECIPHER(SALSA20)
 
@@ -612,11 +613,11 @@ INSTANCE_BLOCKEDSTREAMNONCECIPHER(SALSA20)
 {-|
 'ESTREAM_SALSA20' is the same as 'SALSA20', but uses only 12 instead of 20 rounds in mixing.
 -}
-newtype ESTREAM_SALSA20 = ESTREAM_SALSA20 (SecureMem, B.ByteString)
+newtype ESTREAM_SALSA20 = ESTREAM_SALSA20 (BA.ScrubbedBytes, B.ByteString)
 instance NettleCipher ESTREAM_SALSA20 where
 	nc_cipherInit    = Tagged wrap_salsa20_set_key
 	nc_cipherName    = Tagged "eSTREAM-Salsa20"
-	nc_cipherKeySize = Tagged $ KeySizeEnum [16,32]
+	nc_cipherKeySize = Tagged $ CCT.KeySizeEnum [16,32]
 	nc_ctx_size      = Tagged c_salsa20_ctx_size
 	nc_ctx (ESTREAM_SALSA20 (c, _)) = c
 	nc_Ctx c           = ESTREAM_SALSA20 (c, B.empty)
@@ -625,6 +626,6 @@ instance NettleBlockedStreamCipher ESTREAM_SALSA20 where
 	nbsc_IncompleteState (ESTREAM_SALSA20 (c, _)) inc = ESTREAM_SALSA20 (c, inc)
 	nbsc_incompleteState (ESTREAM_SALSA20 (_, inc)) = inc
 	nbsc_streamCombine = Tagged c_salsa20r12_crypt
-	nbsc_nonceSize     = Tagged $ KeySizeFixed 8
+	nbsc_nonceSize     = Tagged $ CCT.KeySizeFixed 8
 	nbsc_setNonce      = Tagged $ Just wrap_salsa20_set_nonce
 INSTANCE_BLOCKEDSTREAMNONCECIPHER(ESTREAM_SALSA20)

--- a/src/Crypto/Nettle/Ciphers/Internal.hs
+++ b/src/Crypto/Nettle/Ciphers/Internal.hs
@@ -1,11 +1,12 @@
 {-# OPTIONS_HADDOCK hide #-}
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FlexibleContexts, LambdaCase #-}
 
 module Crypto.Nettle.Ciphers.Internal
 	( NettleCipher(..)
 	, NettleBlockCipher(..)
 	, NettleStreamCipher(..)
 	, NettleBlockedStreamCipher(..)
+	, NettleAeadModeImpl(..)
 	, NettleGCM
 	, nettle_cipherInit
 	, nettle_cipherInit'
@@ -27,14 +28,12 @@ module Crypto.Nettle.Ciphers.Internal
 	, nettle_gcm_aeadStateFinalize
 	) where
 
-import Crypto.Cipher.Types as T
+import Crypto.Cipher.Types as CCT
+import Crypto.Error
 
 import Data.Tagged
-import Data.Byteable (Byteable(..))
-import Data.SecureMem
+import qualified Data.ByteArray as BA
 import qualified Data.ByteString as B
-import qualified Data.ByteString.Internal as B
-import Data.Bits (xor)
 
 import Nettle.Utils
 import Crypto.Nettle.Ciphers.ForeignImports
@@ -46,10 +45,10 @@ class NettleCipher c where
 	-- | pointer to new context, key length, (const) key pointer
 	nc_cipherInit    :: Tagged c (Ptr Word8 -> Word -> Ptr Word8 -> IO())
 	nc_cipherName    :: Tagged c String
-	nc_cipherKeySize :: Tagged c T.KeySizeSpecifier
+	nc_cipherKeySize :: Tagged c CCT.KeySizeSpecifier
 	nc_ctx_size      :: Tagged c Int
-	nc_ctx           :: c -> SecureMem
-	nc_Ctx           :: SecureMem -> c
+	nc_ctx           :: c -> BA.ScrubbedBytes
+	nc_Ctx           :: BA.ScrubbedBytes -> c
 class NettleCipher c => NettleBlockCipher c where
 	nbc_blockSize          :: Tagged c Int
 	nbc_encrypt_ctx_offset :: Tagged c (Ptr Word8 -> Ptr Word8)
@@ -62,8 +61,8 @@ class NettleCipher c => NettleBlockCipher c where
 	nbc_fun_decrypt        :: Tagged c (FunPtr NettleCryptFunc)
 class NettleCipher c => NettleStreamCipher c where
 	nsc_streamCombine      :: Tagged c NettleCryptFunc
-	nsc_nonceSize          :: Tagged c T.KeySizeSpecifier
-	nsc_nonceSize          = Tagged $ T.KeySizeEnum []
+	nsc_nonceSize          :: Tagged c CCT.KeySizeSpecifier
+	nsc_nonceSize          = Tagged $ CCT.KeySizeEnum []
 	nsc_setNonce           :: Tagged c (Maybe (Ptr Word8 -> Word -> Ptr Word8 -> IO ()))
 	nsc_setNonce           = Tagged Nothing
 
@@ -75,183 +74,205 @@ class NettleCipher c => NettleBlockedStreamCipher c where
 	nbsc_IncompleteState    :: c -> B.ByteString -> c
 	nbsc_incompleteState    :: c -> B.ByteString
 	nbsc_streamCombine      :: Tagged c NettleCryptFunc
-	nbsc_nonceSize          :: Tagged c T.KeySizeSpecifier
-	nbsc_nonceSize          = Tagged $ T.KeySizeEnum []
+	nbsc_nonceSize          :: Tagged c CCT.KeySizeSpecifier
+	nbsc_nonceSize          = Tagged $ CCT.KeySizeEnum []
 	nbsc_setNonce           :: Tagged c (Maybe (Ptr Word8 -> Word -> Ptr Word8 -> IO ()))
 	nbsc_setNonce           = Tagged Nothing
 
-nettle_cipherInit :: NettleCipher c => Key c -> c
-nettle_cipherInit k = let ctx = nettle_cipherInit' (nc_cipherInit `witness` ctx) k in ctx
+class NettleAeadModeImpl c state where
+	nettle_aead_mode_impl :: c -> CCT.AEADModeImpl state
 
-nettle_cipherInit' :: NettleCipher c => (Ptr Word8 -> Word -> Ptr Word8 -> IO()) -> Key c -> c
-nettle_cipherInit' f k = let ctx = nc_Ctx $ key_init f (nc_ctx_size `witness` ctx) k in ctx
+nettle_cipherInit :: (NettleCipher c, BA.ByteArray key) => key -> CryptoFailable c
+nettle_cipherInit k = let ctx = nettle_cipherInit' (nc_cipherInit `witness` (throwCryptoError ctx)) k in ctx
 
-assert_blockSize :: NettleBlockCipher c => c -> B.ByteString -> a -> a
-assert_blockSize c src result = if 0 /= B.length src `mod` (nbc_blockSize `witness` c) then error "input not a multiple of blockSize" else result
+nettle_cipherInit' :: (NettleCipher c, BA.ByteArray key) => (Ptr Word8 -> Word -> Ptr Word8 -> IO()) -> key -> CryptoFailable c
+nettle_cipherInit' f k = let ctx = (\case {
+		  Nothing -> CryptoPassed $ nc_Ctx $ key_init f (nc_ctx_size `witness` (throwCryptoError ctx)) k
+		; Just e -> CryptoFailed e
+		}) (validate_keySize (nc_cipherKeySize `witness` (throwCryptoError ctx)) k)
+	in ctx
 
-nettle_ecbEncrypt :: NettleBlockCipher c => c -> B.ByteString -> B.ByteString
+validate_keySize :: (BA.ByteArrayAccess key) => CCT.KeySizeSpecifier -> key -> Maybe CryptoError
+validate_keySize spec k = case spec of
+	CCT.KeySizeRange bot top -> if bot <= BA.length k && BA.length k <= top	then Nothing else Just CryptoError_KeySizeInvalid
+	CCT.KeySizeEnum list     -> if (BA.length k) `elem` list		then Nothing else Just CryptoError_KeySizeInvalid
+	CCT.KeySizeFixed f       -> if BA.length k == f				then Nothing else Just CryptoError_KeySizeInvalid
+
+assert_blockSize :: (NettleBlockCipher c, BA.ByteArrayAccess ba) => c -> ba -> a -> a
+assert_blockSize c src result = if 0 /= BA.length src `mod` (nbc_blockSize `witness` c) then error "input not a multiple of blockSize" else result
+
+nettle_ecbEncrypt :: (CCT.BlockCipher c, NettleBlockCipher c, BA.ByteArrayAccess bin, BA.ByteArray bout) => c -> bin -> bout
 nettle_ecbEncrypt c    src = assert_blockSize c src $ c_run_crypt   (nbc_encrypt_ctx_offset `witness` c)               (nbc_ecb_encrypt `witness` c) (nc_ctx c) src
-nettle_ecbDecrypt :: NettleBlockCipher c => c -> B.ByteString -> B.ByteString
+nettle_ecbDecrypt :: (CCT.BlockCipher c, NettleBlockCipher c, BA.ByteArrayAccess bin, BA.ByteArray bout) => c -> bin -> bout
 nettle_ecbDecrypt c    src = assert_blockSize c src $ c_run_crypt   (nbc_decrypt_ctx_offset `witness` c)               (nbc_ecb_decrypt `witness` c) (nc_ctx c) src
-nettle_cbcEncrypt :: NettleBlockCipher c => c -> IV c -> B.ByteString -> B.ByteString
+nettle_cbcEncrypt :: (CCT.BlockCipher c, NettleBlockCipher c, BA.ByteArrayAccess bin, BA.ByteArray bout) => c -> IV c -> bin -> bout
 nettle_cbcEncrypt c iv src = assert_blockSize c src $ blockmode_run (nbc_encrypt_ctx_offset `witness` c) c_cbc_encrypt (nbc_fun_encrypt `witness` c) (nc_ctx c) iv src
-nettle_cbcDecrypt :: NettleBlockCipher c => c -> IV c -> B.ByteString -> B.ByteString
+nettle_cbcDecrypt :: (CCT.BlockCipher c, NettleBlockCipher c, BA.ByteArrayAccess bin, BA.ByteArray bout) => c -> IV c -> bin -> bout
 nettle_cbcDecrypt c iv src = assert_blockSize c src $ blockmode_run (nbc_decrypt_ctx_offset `witness` c) c_cbc_decrypt (nbc_fun_decrypt `witness` c) (nc_ctx c) iv src
-nettle_cfbEncrypt :: NettleBlockCipher c => c -> IV c -> B.ByteString -> B.ByteString
+nettle_cfbEncrypt :: (CCT.BlockCipher c, NettleBlockCipher c, BA.ByteArrayAccess bin, BA.ByteArray bout) => c -> IV c -> bin -> bout
 nettle_cfbEncrypt c iv src = assert_blockSize c src $ blockmode_run (nbc_encrypt_ctx_offset `witness` c) c_cfb_encrypt (nbc_fun_encrypt `witness` c) (nc_ctx c) iv src
-nettle_cfbDecrypt :: NettleBlockCipher c => c -> IV c -> B.ByteString -> B.ByteString
+nettle_cfbDecrypt :: (CCT.BlockCipher c, NettleBlockCipher c, BA.ByteArrayAccess bin, BA.ByteArray bout) => c -> IV c -> bin -> bout
 nettle_cfbDecrypt c iv src = assert_blockSize c src $ blockmode_run (nbc_encrypt_ctx_offset `witness` c) c_cfb_decrypt (nbc_fun_encrypt `witness` c) (nc_ctx c) iv src
-nettle_ctrCombine :: NettleBlockCipher c => c -> IV c -> B.ByteString -> B.ByteString
+nettle_ctrCombine :: (CCT.BlockCipher c, NettleBlockCipher c, BA.ByteArrayAccess bin, BA.ByteArray bout) => c -> IV c -> bin -> bout
 nettle_ctrCombine c        =                          blockmode_run (nbc_encrypt_ctx_offset `witness` c) c_ctr_crypt   (nbc_fun_encrypt `witness` c) (nc_ctx c)
 
-nettle_streamCombine :: NettleStreamCipher c => c -> B.ByteString -> (B.ByteString, c)
+nettle_streamCombine :: (NettleStreamCipher c, BA.ByteArrayAccess bin, BA.ByteArray bout) => c -> bin -> (bout, c)
 nettle_streamCombine c indata = let (r, c') = stream_crypt (nsc_streamCombine `witness` c) (nc_ctx c) indata in (r, nc_Ctx c')
 nettle_streamSetNonce :: NettleStreamCipher c => c -> B.ByteString -> Maybe c
 nettle_streamSetNonce c nonce = case nsc_setNonce `witness` c of
 	Nothing -> Nothing
-	Just setnonce -> unsafeDupablePerformIO $
-		secureMemCopy (nc_ctx c) >>= \ctx' ->
-		withSecureMemPtr ctx' $ \ctxptr ->
+	Just setnonce -> let ctx' = copyScrubbedBytes (nc_ctx c) in
+		unsafeDupablePerformIO $
+		BA.withByteArray ctx' $ \ctxptr ->
 		withByteStringPtr nonce $ \noncelen nonceptr ->
 		setnonce ctxptr noncelen nonceptr >>
 		return (Just $ nc_Ctx ctx')
 
-nettle_blockedStreamCombine :: NettleBlockedStreamCipher c => c -> B.ByteString -> (B.ByteString, c)
-nettle_blockedStreamCombine c indata = if B.length indata == 0 then (indata, c) else
+nettle_blockedStreamCombine :: (NettleBlockedStreamCipher c, BA.ByteArray bin, BA.ByteArray bout) => c -> bin -> (bout, c)
+nettle_blockedStreamCombine c indata = if BA.length indata == 0 then (BA.convert indata, c) else
 	let inc = nbsc_incompleteState c; blocksiz = nbsc_blockSize `witness` c in
 	if B.length inc /= 0
 		then let
 			-- first xor remaining block, then combine the rest
-			(i1, i2) = B.splitAt (B.length inc) indata
-			(inc1, inc2) = B.splitAt (B.length indata) inc
-			r1 = B.pack $ B.zipWith xor i1 inc1
+			(i1, i2) = BA.splitAt (B.length inc) indata
+			(inc1, inc2) = B.splitAt (BA.length indata) inc
+			r1 = BA.xor i1 inc1
 			c' = if B.length inc2 == 0 then nc_Ctx $ nc_ctx c else nbsc_IncompleteState c inc2
 			(r, c'') = nettle_blockedStreamCombine c' i2
-			in (B.append r1 r, c'')
-		else if B.length indata `mod` blocksiz /= 0
+			in (BA.append r1 r, c'')
+		else if BA.length indata `mod` blocksiz /= 0
 			then let
-				padding = B.replicate (blocksiz - (B.length indata `mod` blocksiz)) 0
-				(r', c') = stream_crypt (nbsc_streamCombine `witness` c) (nc_ctx c) (B.append indata padding)
-				(r, inc') = B.splitAt (B.length indata) r'
-				in (r, nbsc_IncompleteState (nc_Ctx c') inc')
+				padding = BA.replicate (blocksiz - (BA.length indata `mod` blocksiz)) 0
+				(r', c') = stream_crypt (nbsc_streamCombine `witness` c) (nc_ctx c) (BA.append indata padding)
+				(r, inc') = BA.splitAt (BA.length indata) r'
+				in (r, nbsc_IncompleteState (nc_Ctx c') (BA.convert inc'))
 			else
 				let (r, c') = stream_crypt (nbsc_streamCombine `witness` c) (nc_ctx c) indata in (r, nc_Ctx c')
 nettle_blockedStreamSetNonce :: NettleBlockedStreamCipher c => c -> B.ByteString -> Maybe c
 nettle_blockedStreamSetNonce c nonce = case nbsc_setNonce `witness` c of
 	Nothing -> Nothing
-	Just setnonce -> unsafeDupablePerformIO $
-		secureMemCopy (nc_ctx c) >>= \ctx' ->
-		withSecureMemPtr ctx' $ \ctxptr ->
+	Just setnonce -> let ctx' = copyScrubbedBytes (nc_ctx c) in
+		unsafeDupablePerformIO $
+		BA.withByteArray ctx' $ \ctxptr ->
 		withByteStringPtr nonce $ \noncelen nonceptr ->
 		setnonce ctxptr noncelen nonceptr >>
 		return (Just $ nc_Ctx ctx')
 
 
-nettle_gcm_aeadInit              :: (NettleBlockCipher c, AEADModeImpl c NettleGCM, Byteable iv) => c -> iv -> Maybe (AEAD c)
-nettle_gcm_aeadInit          c  iv = if nbc_blockSize `witness` c == 16 then Just $ AEAD c $ AEADState $ gcm_init (nbc_encrypt_ctx_offset `witness` c) (nbc_fun_encrypt `witness` c) (nc_ctx c) iv else Nothing
-nettle_gcm_aeadStateAppendHeader :: t -> NettleGCM -> B.ByteString -> NettleGCM
+nettle_gcm_aeadInit              :: (NettleBlockCipher c, NettleAeadModeImpl c NettleGCM, BA.ByteArrayAccess iv) => c -> iv -> CryptoFailable (CCT.AEAD c)
+nettle_gcm_aeadInit          c  iv = if nbc_blockSize `witness` c == 16 then CryptoPassed $ CCT.AEAD {CCT.aeadModeImpl = nettle_aead_mode_impl c, CCT.aeadState = gcm_init (nbc_encrypt_ctx_offset `witness` c) (nbc_fun_encrypt `witness` c) (nc_ctx c) iv} else CryptoFailed CryptoError_AEADModeNotSupported
+nettle_gcm_aeadStateAppendHeader :: BA.ByteArrayAccess ba => t -> NettleGCM -> ba -> NettleGCM
 nettle_gcm_aeadStateAppendHeader _ = gcm_update
-nettle_gcm_aeadStateEncrypt      :: NettleBlockCipher c => c -> NettleGCM -> B.ByteString -> (B.ByteString, NettleGCM)
+nettle_gcm_aeadStateEncrypt      :: (NettleBlockCipher c, BA.ByteArrayAccess bin, BA.ByteArray bout) => c -> NettleGCM -> bin -> (bout, NettleGCM)
 nettle_gcm_aeadStateEncrypt      c = gcm_crypt c_gcm_encrypt (nbc_encrypt_ctx_offset `witness` c) (nbc_fun_encrypt `witness` c) (nc_ctx c)
-nettle_gcm_aeadStateDecrypt      :: NettleBlockCipher c => c -> NettleGCM -> B.ByteString -> (B.ByteString, NettleGCM)
+nettle_gcm_aeadStateDecrypt      :: (NettleBlockCipher c, BA.ByteArrayAccess bin, BA.ByteArray bout) => c -> NettleGCM -> bin -> (bout, NettleGCM)
 nettle_gcm_aeadStateDecrypt      c = gcm_crypt c_gcm_decrypt (nbc_encrypt_ctx_offset `witness` c) (nbc_fun_encrypt `witness` c) (nc_ctx c)
-nettle_gcm_aeadStateFinalize     :: NettleBlockCipher c => c -> NettleGCM -> Int -> AuthTag
+nettle_gcm_aeadStateFinalize     :: NettleBlockCipher c => c -> NettleGCM -> Int -> CCT.AuthTag
 nettle_gcm_aeadStateFinalize     c = gcm_digest              (nbc_encrypt_ctx_offset `witness` c) (nbc_fun_encrypt `witness` c) (nc_ctx c)
 
 
 
 key_init
-	:: ToSecureMem k
+	:: BA.ByteArrayAccess k
 	=> (Ptr Word8 -> Word -> Ptr Word8 -> IO ())
-	-> Int -> k -> SecureMem
-key_init initfun size k = unsafeCreateSecureMem size $ \ctxptr ->
-	withSecureMemPtrSz (toSecureMem k) $ \ksize kptr -> initfun ctxptr (fromIntegral ksize) kptr
+	-> Int -> k -> BA.ScrubbedBytes
+key_init initfun size k = BA.unsafeCreate size $ \ctxptr ->
+	BA.withByteArray k $ \kptr -> initfun ctxptr (fromIntegral $ BA.length k) kptr
 
 -- run encryption/decryption with same length for in and output
 c_run_crypt
-	:: (Ptr Word8 -> Ptr Word8)
+	:: (BA.ByteArrayAccess bin,
+	    BA.ByteArray bout)
+	=> (Ptr Word8 -> Ptr Word8)
 	-> NettleCryptFunc
-	-> SecureMem -> B.ByteString -> B.ByteString
-c_run_crypt ctxoffset cfun ctx indata = unsafeDupablePerformIO $ withSecureMemPtr ctx $ \ctxptr ->
-	withByteStringPtr indata $ \indatalen indataptr ->
-	B.create (B.length indata) $ \outptr ->
-	cfun (ctxoffset ctxptr) indatalen outptr indataptr
+	-> BA.ScrubbedBytes -> bin -> bout
+c_run_crypt ctxoffset cfun ctx indata = unsafeDupablePerformIO $ BA.withByteArray ctx $ \ctxptr ->
+	BA.withByteArray indata $ \indataptr ->
+	BA.create (BA.length indata) $ \outptr ->
+	cfun (ctxoffset ctxptr) (fromIntegral $ BA.length indata) outptr indataptr
 
 blockmode_run
-	:: (Byteable iv)
+	:: (BA.ByteArrayAccess iv,
+	    BA.ByteArrayAccess bin,
+	    BA.ByteArray bout)
 	=> (Ptr Word8 -> Ptr Word8)
 	-> NettleBlockMode
 	-> FunPtr NettleCryptFunc
-	-> SecureMem -> iv -> B.ByteString -> B.ByteString
-blockmode_run ctxoffset mode crypt ctx iv indata = unsafeDupablePerformIO $ withSecureMemPtr ctx $ \ctxptr ->
-	withByteStringPtr indata $ \indatalen indataptr ->
-	withSecureMemPtrSz (toSecureMem $ toBytes iv) $ \ivlen ivptr -> -- copy IV, may get modified
-	B.create (B.length indata) $ \outptr ->
-	mode (ctxoffset ctxptr) crypt (fromIntegral ivlen) ivptr indatalen outptr indataptr
+	-> BA.ScrubbedBytes -> iv -> bin -> bout
+blockmode_run ctxoffset mode crypt ctx iv indata = let iv' = copyAndConvertToScrubbedBytes iv in -- copy IV, may get modified
+	unsafeDupablePerformIO $ BA.withByteArray ctx $ \ctxptr ->
+	BA.withByteArray indata $ \indataptr ->
+	BA.withByteArray iv' $ \ivptr ->
+	BA.create (BA.length indata) $ \outptr ->
+	mode (ctxoffset ctxptr) crypt (fromIntegral $ BA.length iv') ivptr (fromIntegral $ BA.length indata) outptr indataptr
 
-data NettleGCM = NettleGCM !SecureMem !SecureMem
+data NettleGCM = NettleGCM !BA.ScrubbedBytes !BA.ScrubbedBytes
 
 gcm_init
-	:: (Byteable iv)
+	:: BA.ByteArrayAccess iv
 	=> (Ptr Word8 -> Ptr Word8)
 	-> FunPtr NettleCryptFunc
-	-> SecureMem -> iv -> NettleGCM
+	-> BA.ScrubbedBytes -> iv -> NettleGCM
 gcm_init encctxoffset encrypt encctx iv = unsafeDupablePerformIO $
-	withBytePtr iv $ \ivptr ->
-	withSecureMemPtr encctx $ \encctxptr -> do
-	h <- createSecureMem c_gcm_key_size $ \hptr ->
+	BA.withByteArray iv $ \ivptr ->
+	BA.withByteArray encctx $ \encctxptr -> do
+	h <- BA.create c_gcm_key_size $ \hptr ->
 		c_gcm_set_key hptr (encctxoffset encctxptr) encrypt
-	withSecureMemPtr h $ \hptr -> do
-	    ctx <- createSecureMem c_gcm_ctx_size $ \ctxptr ->
-		c_gcm_set_iv ctxptr hptr (fromIntegral $ byteableLength iv) ivptr
+	BA.withByteArray h $ \hptr -> do
+	    ctx <- BA.create c_gcm_ctx_size $ \ctxptr ->
+		c_gcm_set_iv ctxptr hptr (fromIntegral $ BA.length iv) ivptr
 	    return (NettleGCM ctx h)
 
 -- independent of cipher
 gcm_update
-	:: NettleGCM -> B.ByteString -> NettleGCM
-gcm_update (NettleGCM ctx h) indata = unsafeDupablePerformIO $
-	secureMemCopy ctx >>= \ctx' ->
-	withSecureMemPtr ctx' $ \ctxptr ->
-	withSecureMemPtr h $ \hptr ->
-	withByteStringPtr indata $ \indatalen indataptr ->
-	c_gcm_update ctxptr hptr indatalen indataptr >>
+	:: BA.ByteArrayAccess ba => NettleGCM -> ba -> NettleGCM
+gcm_update (NettleGCM ctx h) indata = let ctx' = copyScrubbedBytes ctx in
+	unsafeDupablePerformIO $
+	BA.withByteArray ctx' $ \ctxptr ->
+	BA.withByteArray h $ \hptr ->
+	BA.withByteArray indata $ \indataptr ->
+	c_gcm_update ctxptr hptr (fromIntegral $ BA.length indata) indataptr >>
 	return (NettleGCM ctx' h)
 
 gcm_crypt
-	:: NettleGCMMode
+	:: (BA.ByteArrayAccess bin,
+	    BA.ByteArray bout)
+	=> NettleGCMMode
 	-> (Ptr Word8 -> Ptr Word8)
 	-> FunPtr NettleCryptFunc
-	-> SecureMem -> NettleGCM -> B.ByteString -> (B.ByteString, NettleGCM)
-gcm_crypt mode encctxoffset encrypt encctx (NettleGCM ctx h) indata = unsafeDupablePerformIO $
-	secureMemCopy ctx >>= \ctx' ->
-	withSecureMemPtr ctx' $ \ctxptr ->
-	withSecureMemPtr h $ \hptr ->
-	withSecureMemPtr encctx $ \encctxptr ->
-	withByteStringPtr indata $ \indatalen indataptr -> do
-	outdata <- B.create (B.length indata) $ \outptr ->
-		mode ctxptr hptr (encctxoffset encctxptr) encrypt indatalen outptr indataptr
+	-> BA.ScrubbedBytes -> NettleGCM -> bin -> (bout, NettleGCM)
+gcm_crypt mode encctxoffset encrypt encctx (NettleGCM ctx h) indata = let ctx' = copyScrubbedBytes ctx in
+	unsafeDupablePerformIO $
+	BA.withByteArray ctx' $ \ctxptr ->
+	BA.withByteArray h $ \hptr ->
+	BA.withByteArray encctx $ \encctxptr ->
+	BA.withByteArray indata $ \indataptr -> do
+	outdata <- BA.create (BA.length indata) $ \outptr ->
+		mode ctxptr hptr (encctxoffset encctxptr) encrypt (fromIntegral $ BA.length indata) outptr indataptr
 	return (outdata, NettleGCM ctx' h)
 
 gcm_digest
 	:: (Ptr Word8 -> Ptr Word8)
 	-> FunPtr NettleCryptFunc
-	-> SecureMem -> NettleGCM -> Int -> AuthTag
-gcm_digest encctxoffset encrypt encctx (NettleGCM ctx h) taglen = unsafeDupablePerformIO $
-	secureMemCopy ctx >>= \ctx' ->
-	withSecureMemPtr ctx' $ \ctxptr ->
-	withSecureMemPtr h $ \hptr ->
-	withSecureMemPtr encctx $ \encctxptr -> do
-	tag <- B.create (fromIntegral taglen) $ \tagptr ->
+	-> BA.ScrubbedBytes -> NettleGCM -> Int -> CCT.AuthTag
+gcm_digest encctxoffset encrypt encctx (NettleGCM ctx h) taglen = let ctx' = copyScrubbedBytes ctx in
+	unsafeDupablePerformIO $
+	BA.withByteArray ctx' $ \ctxptr ->
+	BA.withByteArray h $ \hptr ->
+	BA.withByteArray encctx $ \encctxptr -> do
+	tag <- BA.create (fromIntegral taglen) $ \tagptr ->
 		c_gcm_digest ctxptr hptr (encctxoffset encctxptr) encrypt (fromIntegral taglen) tagptr
-	return $ AuthTag tag
+	return $ CCT.AuthTag tag
 
 stream_crypt
-	:: NettleCryptFunc
-	-> SecureMem -> B.ByteString -> (B.ByteString, SecureMem)
-stream_crypt crypt ctx indata = unsafeDupablePerformIO $
-	secureMemCopy ctx >>= \ctx' ->
-	withSecureMemPtr ctx' $ \ctxptr ->
-	withByteStringPtr indata $ \indatalen indataptr -> do
-	outdata <- B.create (B.length indata) $ \outptr ->
-		crypt ctxptr indatalen outptr indataptr
+	:: (BA.ByteArrayAccess bin,
+	    BA.ByteArray bout)
+	=> NettleCryptFunc
+	-> BA.ScrubbedBytes -> bin -> (bout, BA.ScrubbedBytes)
+stream_crypt crypt ctx indata = let ctx' = copyScrubbedBytes ctx in
+	unsafeDupablePerformIO $
+	BA.withByteArray ctx' $ \ctxptr ->
+	BA.withByteArray indata $ \indataptr -> do
+	outdata <- BA.create (BA.length indata) $ \outptr ->
+		crypt ctxptr (fromIntegral $ BA.length indata) outptr indataptr
 	return (outdata, ctx')

--- a/src/Crypto/Nettle/Hash.hs
+++ b/src/Crypto/Nettle/Hash.hs
@@ -64,7 +64,7 @@ import Crypto.Nettle.Hash.ForeignImports
 import Crypto.Nettle.Hash.Types
 import Nettle.Utils
 
-import Data.SecureMem
+import qualified Data.ByteArray as BA
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Internal as B
 
@@ -81,22 +81,22 @@ nettleHashInit       :: NettleHashAlgorithm a => a
 nettleHashInit = untagSelf $ do
 		size <- nha_ctx_size
 		initfun <- nha_init
-		return $ nha_Ctx $ unsafeCreateSecureMem size $ \ctxptr ->
+		return $ nha_Ctx $ BA.unsafeCreate size $ \ctxptr ->
 			initfun ctxptr
 nettleHashUpdate     :: NettleHashAlgorithm a => a -> B.ByteString -> a
 nettleHashUpdate c msg = untagSelf $ do
 	updatefun <- nha_update
-	return $ nha_Ctx $ unsafeDupablePerformIO $
-		withSecureMemCopy (nha_ctx c) $ \ctxptr ->
+	return $ nha_Ctx $ BA.copyAndFreeze (nha_ctx c) $ \ctxptr ->
 		withByteStringPtr msg $ \msglen msgptr ->
 			updatefun ctxptr msglen msgptr
 nettleHashFinalize   :: NettleHashAlgorithm a => a -> B.ByteString
 nettleHashFinalize c = flip witness c $ do
+	let ctx = copyScrubbedBytes (nha_ctx c)
 	digestSize <- nha_digest_size
 	digestfun <- nha_digest
 	return $ unsafeDupablePerformIO $
 		B.create digestSize $ \digestptr -> do
-			_ <- withSecureMemCopy (nha_ctx c) $ \ctxptr ->
+			_ <- BA.withByteArray ctx $ \ctxptr ->
 #if (NETTLE_VERSION_MAJOR >= 4)
 				digestfun ctxptr digestptr
 #else
@@ -112,8 +112,8 @@ class NettleHashAlgorithm a where
 	nha_init        :: Tagged a NettleHashInit
 	nha_update      :: Tagged a NettleHashUpdate
 	nha_digest      :: Tagged a NettleHashDigest
-	nha_ctx         :: a -> SecureMem
-	nha_Ctx         :: SecureMem -> a
+	nha_ctx         :: a -> BA.ScrubbedBytes
+	nha_Ctx         :: BA.ScrubbedBytes -> a
 
 #define INSTANCE_HASH(Typ) \
 instance HashAlgorithm Typ where \
@@ -127,7 +127,7 @@ instance HashAlgorithm Typ where \
 
 -- | The GOST94 or GOST R 34.11-94 hash algorithm is a Soviet-era algorithm used in Russian government standards (see RFC 4357).
 --   It outputs message digests of 32 bytes (256 bits).
-data GOSTHASH94 = GOSTHASH94 { gosthash94_ctx :: SecureMem }
+data GOSTHASH94 = GOSTHASH94 { gosthash94_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm GOSTHASH94 where
 	nha_ctx_size    = Tagged c_gosthash94_ctx_size
 	nha_block_size  = Tagged c_gosthash94_block_size
@@ -143,7 +143,7 @@ INSTANCE_HASH(GOSTHASH94)
 
 
 -- | 'MD2' is a hash function of Ronald Rivest's, described in RFC 1319. It outputs message digests of 16 bytes (128 bits).
-data MD2 = MD2 { md2_ctx :: SecureMem }
+data MD2 = MD2 { md2_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm MD2 where
 	nha_ctx_size    = Tagged c_md2_ctx_size
 	nha_block_size  = Tagged c_md2_block_size
@@ -157,7 +157,7 @@ instance NettleHashAlgorithm MD2 where
 INSTANCE_HASH(MD2)
 
 -- | 'MD4' is a hash function of Ronald Rivest's, described in RFC 1320. It outputs message digests of 16 bytes (128 bits).
-data MD4 = MD4 { md4_ctx :: SecureMem }
+data MD4 = MD4 { md4_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm MD4 where
 	nha_ctx_size    = Tagged c_md4_ctx_size
 	nha_block_size  = Tagged c_md4_block_size
@@ -171,7 +171,7 @@ instance NettleHashAlgorithm MD4 where
 INSTANCE_HASH(MD4)
 
 -- | 'MD5' is a hash function of Ronald Rivest's, described in RFC 1321. It outputs message digests of 16 bytes (128 bits).
-data MD5 = MD5 { md5_ctx :: SecureMem }
+data MD5 = MD5 { md5_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm MD5 where
 	nha_ctx_size    = Tagged c_md5_ctx_size
 	nha_block_size  = Tagged c_md5_block_size
@@ -186,7 +186,7 @@ INSTANCE_HASH(MD5)
 
 -- | 'RIPEMD160' is a hash function designed by Hans Dobbertin, Antoon Bosselaers, and Bart Preneel, as a strengthened version of RIPEMD.
 --   It produces message digests of 20 bytes (160 bits).
-data RIPEMD160 = RIPEMD160 { ripemd160_ctx :: SecureMem }
+data RIPEMD160 = RIPEMD160 { ripemd160_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm RIPEMD160 where
 	nha_ctx_size    = Tagged c_ripemd160_ctx_size
 	nha_block_size  = Tagged c_ripemd160_block_size
@@ -202,7 +202,7 @@ INSTANCE_HASH(RIPEMD160)
 
 -- | 'SHA1' is a hash function specified by NIST (The U.S. National Institute for Standards and Technology).
 --   It produces message digests of 20 bytes (160 bits).
-data SHA1 = SHA1 { sha1_ctx :: SecureMem }
+data SHA1 = SHA1 { sha1_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm SHA1 where
 	nha_ctx_size    = Tagged c_sha1_ctx_size
 	nha_block_size  = Tagged c_sha1_block_size
@@ -216,7 +216,7 @@ instance NettleHashAlgorithm SHA1 where
 INSTANCE_HASH(SHA1)
 
 -- | 'SHA224' is a member of the SHA2 family which outputs messages digests of 28 bytes (224 bits).
-data SHA224 = SHA224 { sha224_ctx :: SecureMem }
+data SHA224 = SHA224 { sha224_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm SHA224 where
 	nha_ctx_size    = Tagged c_sha224_ctx_size
 	nha_block_size  = Tagged c_sha224_block_size
@@ -230,7 +230,7 @@ instance NettleHashAlgorithm SHA224 where
 INSTANCE_HASH(SHA224)
 
 -- | 'SHA256' is a member of the SHA2 family which outputs messages digests of 32 bytes (256 bits).
-data SHA256 = SHA256 { sha256_ctx :: SecureMem }
+data SHA256 = SHA256 { sha256_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm SHA256 where
 	nha_ctx_size    = Tagged c_sha256_ctx_size
 	nha_block_size  = Tagged c_sha256_block_size
@@ -244,7 +244,7 @@ instance NettleHashAlgorithm SHA256 where
 INSTANCE_HASH(SHA256)
 
 -- | 'SHA384' is a member of the SHA2 family which outputs messages digests of 48 bytes (384 bits).
-data SHA384 = SHA384 { sha384_ctx :: SecureMem }
+data SHA384 = SHA384 { sha384_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm SHA384 where
 	nha_ctx_size    = Tagged c_sha384_ctx_size
 	nha_block_size  = Tagged c_sha384_block_size
@@ -258,7 +258,7 @@ instance NettleHashAlgorithm SHA384 where
 INSTANCE_HASH(SHA384)
 
 -- | 'SHA512' is a member of the SHA2 family which outputs messages digests of 64 bytes (512 bits).
-data SHA512 = SHA512 { sha512_ctx :: SecureMem }
+data SHA512 = SHA512 { sha512_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm SHA512 where
 	nha_ctx_size    = Tagged c_sha512_ctx_size
 	nha_block_size  = Tagged c_sha512_block_size
@@ -272,7 +272,7 @@ instance NettleHashAlgorithm SHA512 where
 INSTANCE_HASH(SHA512)
 
 -- | 'SHA3_224' is a member of the SHA3 family which outputs messages digests of 28 bytes (224 bits).
-data SHA3_224 = SHA3_224 { sha3_224_ctx :: SecureMem }
+data SHA3_224 = SHA3_224 { sha3_224_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm SHA3_224 where
 	nha_ctx_size    = Tagged c_sha3_224_ctx_size
 	nha_block_size  = Tagged c_sha3_224_block_size
@@ -290,7 +290,7 @@ instance NettleHashAlgorithm SHA3_224 where
 INSTANCE_HASH(SHA3_224)
 
 -- | 'SHA3_256' is a member of the SHA3 family which outputs messages digests of 32 bytes (256 bits).
-data SHA3_256 = SHA3_256 { sha3_256_ctx :: SecureMem }
+data SHA3_256 = SHA3_256 { sha3_256_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm SHA3_256 where
 	nha_ctx_size    = Tagged c_sha3_256_ctx_size
 	nha_block_size  = Tagged c_sha3_256_block_size
@@ -308,7 +308,7 @@ instance NettleHashAlgorithm SHA3_256 where
 INSTANCE_HASH(SHA3_256)
 
 -- | 'SHA3_384' is a member of the SHA3 family which outputs messages digests of 48 bytes (384 bits).
-data SHA3_384 = SHA3_384 { sha3_384_ctx :: SecureMem }
+data SHA3_384 = SHA3_384 { sha3_384_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm SHA3_384 where
 	nha_ctx_size    = Tagged c_sha3_384_ctx_size
 	nha_block_size  = Tagged c_sha3_384_block_size
@@ -326,7 +326,7 @@ instance NettleHashAlgorithm SHA3_384 where
 INSTANCE_HASH(SHA3_384)
 
 -- | 'SHA3_512' is a member of the SHA3 family which outputs messages digests of 64 bytes (512 bits).
-data SHA3_512 = SHA3_512 { sha3_512_ctx :: SecureMem }
+data SHA3_512 = SHA3_512 { sha3_512_ctx :: BA.ScrubbedBytes }
 instance NettleHashAlgorithm SHA3_512 where
 	nha_ctx_size    = Tagged c_sha3_512_ctx_size
 	nha_block_size  = Tagged c_sha3_512_block_size

--- a/src/Crypto/Nettle/UMAC.hs
+++ b/src/Crypto/Nettle/UMAC.hs
@@ -25,8 +25,8 @@ module Crypto.Nettle.UMAC (
 	, umacInitKeyedHash
 	) where
 
-import Data.SecureMem
 import Data.Tagged
+import qualified Data.ByteArray as BA
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Internal as B
 import qualified Data.ByteString.Lazy as L
@@ -94,8 +94,8 @@ class NettleUMAC u where
 	nu_set_nonce :: Tagged u (Ptr Word8 -> Word -> Ptr Word8 -> IO ())
 	nu_update :: Tagged u (Ptr Word8 -> Word -> Ptr Word8 -> IO ())
 	nu_digest :: Tagged u NettleHashDigest
-	nu_ctx :: u -> SecureMem
-	nu_Ctx :: SecureMem -> u
+	nu_ctx :: u -> BA.ScrubbedBytes
+	nu_Ctx :: BA.ScrubbedBytes -> u
 
 nettleUmacDigestSize :: NettleUMAC u => Tagged u Int
 nettleUmacDigestSize = nu_digest_size
@@ -105,7 +105,7 @@ nettleUmacInit key = if B.length key /= 16 then error "wrong key length" else un
 	go = do
 		size <- nu_ctx_size
 		set_key <- nu_set_key
-		return $ nu_Ctx $ unsafeCreateSecureMem size $ \ctxptr ->
+		return $ nu_Ctx $ BA.unsafeCreate size $ \ctxptr ->
 			withByteStringPtr key $ \_ keyptr ->
 			set_key ctxptr keyptr
 nettleUmacSetNonce :: NettleUMAC u => u -> B.ByteString -> u
@@ -114,7 +114,7 @@ nettleUmacSetNonce c nonce = if B.length nonce < 1 || B.length nonce > 16 then e
 	go ctx = do
 		set_nonce <- nu_set_nonce
 		return $ nu_Ctx $ unsafeDupablePerformIO $
-			withSecureMemCopy (nu_ctx ctx) $ \ctxptr ->
+			BA.copy (nu_ctx ctx) $ \ctxptr ->
 			withByteStringPtr nonce $ \noncelen nonceptr ->
 				set_nonce ctxptr noncelen nonceptr
 nettleUmacUpdate :: NettleUMAC u => u -> B.ByteString -> u
@@ -123,7 +123,7 @@ nettleUmacUpdate c msg = untag $ go c where
 	go ctx = do
 		update <- nu_update
 		return $ nu_Ctx $ unsafeDupablePerformIO $
-			withSecureMemCopy (nu_ctx ctx) $ \ctxptr ->
+			BA.copy (nu_ctx ctx) $ \ctxptr ->
 			withByteStringPtr msg $ \msglen msgptr ->
 				update ctxptr msglen msgptr
 nettleUmacUpdateLazy :: NettleUMAC u => u -> L.ByteString -> u
@@ -132,7 +132,7 @@ nettleUmacUpdateLazy c msg = untag $ go c where
 	go ctx = do
 		update <- nu_update
 		return $ nu_Ctx $ unsafeDupablePerformIO $
-			withSecureMemCopy (nu_ctx ctx) $ \ctxptr ->
+			BA.copy (nu_ctx ctx) $ \ctxptr ->
 			forM_ (L.toChunks msg) $ \chunk ->
 			withByteStringPtr chunk $ \chunklen chunkptr ->
 				update ctxptr chunklen chunkptr
@@ -143,8 +143,8 @@ nettleUmacFinalize c = untag $ go c where
 		digestSize <- nu_digest_size
 		digest <- nu_digest
 		return $ unsafeDupablePerformIO $ do
-			ctx' <- secureMemCopy (nu_ctx ctx)
-			dig <- withSecureMemPtr ctx' $ \ctxptr ->
+			let ctx' = copyScrubbedBytes (nu_ctx ctx)
+			dig <- BA.withByteArray ctx' $ \ctxptr ->
 				B.create digestSize $ \digestptr ->
 #if (NETTLE_VERSION_MAJOR >= 4)
 				digest ctxptr digestptr
@@ -174,7 +174,7 @@ instance KeyedHashAlgorithm Typ where \
 {-|
 'UMAC32' is the 32-bit (4 byte) digest variant. See 'umacInitKeyedHash' for the 'KeyedHashAlgorithm' instance.
 -}
-newtype UMAC32 = UMAC32 { umac32_ctx :: SecureMem }
+newtype UMAC32 = UMAC32 { umac32_ctx :: BA.ScrubbedBytes }
 instance NettleUMAC UMAC32 where
 	nu_ctx_size    = Tagged c_umac32_ctx_size
 	nu_digest_size = Tagged c_umac32_digest_size
@@ -189,7 +189,7 @@ INSTANCE_UMAC(UMAC32)
 {-|
 'UMAC64' is the 64-bit (8 byte) digest variant. See 'umacInitKeyedHash' for the 'KeyedHashAlgorithm' instance.
 -}
-newtype UMAC64 = UMAC64 { umac64_ctx :: SecureMem }
+newtype UMAC64 = UMAC64 { umac64_ctx :: BA.ScrubbedBytes }
 instance NettleUMAC UMAC64 where
 	nu_ctx_size    = Tagged c_umac64_ctx_size
 	nu_digest_size = Tagged c_umac64_digest_size
@@ -204,7 +204,7 @@ INSTANCE_UMAC(UMAC64)
 {-|
 'UMAC96' is the 96-bit (12 byte) digest variant. See 'umacInitKeyedHash' for the 'KeyedHashAlgorithm' instance.
 -}
-newtype UMAC96 = UMAC96 { umac96_ctx :: SecureMem }
+newtype UMAC96 = UMAC96 { umac96_ctx :: BA.ScrubbedBytes }
 instance NettleUMAC UMAC96 where
 	nu_ctx_size    = Tagged c_umac96_ctx_size
 	nu_digest_size = Tagged c_umac96_digest_size
@@ -219,7 +219,7 @@ INSTANCE_UMAC(UMAC96)
 {-|
 'UMAC128' is the 128-bit (16 byte) digest variant. See 'umacInitKeyedHash' for the 'KeyedHashAlgorithm' instance.
 -}
-newtype UMAC128 = UMAC128 { umac128_ctx :: SecureMem }
+newtype UMAC128 = UMAC128 { umac128_ctx :: BA.ScrubbedBytes }
 instance NettleUMAC UMAC128 where
 	nu_ctx_size    = Tagged c_umac128_ctx_size
 	nu_digest_size = Tagged c_umac128_digest_size

--- a/src/Nettle/Utils.hs
+++ b/src/Nettle/Utils.hs
@@ -23,9 +23,14 @@ module Nettle.Utils
 	, forM_
 	, unsafeDupablePerformIO
 	, withByteStringPtr
+	, copyScrubbedBytes
+	, copyAndConvertToScrubbedBytes
+	, createScrubbedBytes
+	, concatToScrubbedBytes
 	, netEncode
 	) where
 
+import qualified Data.ByteArray as BA
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Internal as B
 
@@ -42,6 +47,30 @@ Run action in IO monad with length and pointer to first byte of a 'B.ByteString'
 withByteStringPtr :: B.ByteString -> (Word -> Ptr Word8 -> IO a) -> IO a
 withByteStringPtr b f = withForeignPtr fptr $ \ptr -> f (fromIntegral len) (ptr `plusPtr` off)
 	where (fptr, off, len) = B.toForeignPtr b
+
+{-|
+Copy a 'BA.ScrubbedBytes'.
+-}
+copyScrubbedBytes :: BA.ScrubbedBytes -> BA.ScrubbedBytes
+copyScrubbedBytes ba = BA.copyAndFreeze ba (\_ -> return ())
+
+{-|
+Make a copy of a 'BA.ByteArrayAccess' that gets scrubbed.
+-}
+copyAndConvertToScrubbedBytes :: BA.ByteArrayAccess a => a -> BA.ScrubbedBytes
+copyAndConvertToScrubbedBytes = BA.convert
+
+{-|
+Create a 'BA.ScrubbedBytes'. Used for type hinting.
+-}
+createScrubbedBytes :: Int -> (Ptr p -> IO ()) -> IO BA.ScrubbedBytes
+createScrubbedBytes = BA.create
+
+{-|
+Concatenate a 'BA.ByteArrayAccess' to a 'BA.ScrubbedBytes'. Used for type hinting.
+-}
+concatToScrubbedBytes :: BA.ByteArrayAccess a => [a] -> BA.ScrubbedBytes
+concatToScrubbedBytes = BA.concat
 
 {-|
 Encode any 'Integral' @value@ in @bytes@ 'Word8' as big endian value.

--- a/src/Tests/Ciphers.hs
+++ b/src/Tests/Ciphers.hs
@@ -1,52 +1,20 @@
 
 import Test.Framework (defaultMain, testGroup, Test(..))
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.QuickCheck (Gen(..), elements, choose, vectorOf, label, conjoin)
+import Test.QuickCheck (Gen(..), choose, label, conjoin)
 
 import Crypto.Nettle.Ciphers
 import Crypto.Cipher.Types
-import Crypto.Cipher.Tests
 
 import qualified Data.ByteString as B
 import Data.Word (Word8)
 import qualified Numeric as N
 import Data.Maybe (fromJust)
-import Control.Monad (liftM)
 
+import Ciphers.PropertyTests
+import Ciphers.Utils
 import KAT.AES
-
-fromRight :: Either a b -> b
-fromRight (Right x) = x
-fromRight _ = error "expected Right"
-
-genByteString :: Int -> Gen B.ByteString
-genByteString len = liftM B.pack $ vectorOf len (choose (0,255))
-
-runEither :: (Monad m, Show e) => Either e x -> m x
-runEither (Left e) = error $ show e
-runEither (Right x) = return x
-
-runMaybe :: (Monad m) => Maybe x -> m x
-runMaybe Nothing = error "got nothing"
-runMaybe (Just x) = return x
-
-genKey' :: KeySizeSpecifier -> Gen B.ByteString
-genKey' spec = case spec of
-	KeySizeRange bot top -> choose (bot, top) >>= genByteString
-	KeySizeEnum list     -> elements list >>= genByteString
-	KeySizeFixed f       -> genByteString f
-
-genKey :: Cipher c => c -> Gen (Key c)
-genKey c = genKey' (cipherKeySize c) >>= runEither . makeKey
-
-genCipher :: Cipher c => c -> Gen c
-genCipher c = liftM cipherInit $ genKey c
-
-genIV :: BlockCipher c => c -> Gen (IV c)
-genIV c = genByteString (blockSize c) >>= runMaybe . makeIV
-
-genBlockCipherInput :: BlockCipher c => c -> Int -> Gen B.ByteString
-genBlockCipherInput c blocks = genByteString (blockSize c * blocks)
+import KAT.Utils
 
 genBlockTest :: BlockCipher c => c -> Test
 genBlockTest = genBlockTest' . genCipher
@@ -123,12 +91,12 @@ genArctwoInitEKB :: Gen ARCTWO
 genArctwoInitEKB = do
 	k <- genKey (undefined :: ARCTWO)
 	ekb <- choose (0, 1024)
-	return $ arctwoInitEKB k ekb
+	return $ runCryptoFailable $ arctwoInitEKB k ekb
 
 genArctwoInitGutmann :: Gen ARCTWO
 genArctwoInitGutmann = do
 	k <- genKey (undefined :: ARCTWO)
-	return $ arctwoInitGutmann k
+	return $ runCryptoFailable $ arctwoInitGutmann k
 
 main = defaultMain
 -- own KATs + generated tests (from crypto-cipher-tests)

--- a/src/Tests/Ciphers/KAT.hs
+++ b/src/Tests/Ciphers/KAT.hs
@@ -1,0 +1,41 @@
+
+module Ciphers.KAT
+	( testKATs
+	, testStreamKATs
+	) where
+
+import Test.Framework (Test, TestName, testGroup)
+import Test.Framework.Providers.HUnit (testCase)
+import Test.HUnit ((@?=))
+import Crypto.Cipher.Types as CCT
+import qualified Data.ByteArray as BA
+
+import Ciphers.Utils
+import KAT.Utils
+
+-- | tests related to KATs
+testKATs :: CCT.BlockCipher cipher
+         => KATs
+         -> cipher
+         -> Test
+testKATs kats cipher = testGroup "KAT"
+    (   maybeGroup makeECBTest "ECB" (kat_ECB kats)
+    )
+  where makeECBTest i d =
+            [ testCase ("E" ++ i) (CCT.ecbEncrypt ctx (ecbPlaintext d) @?= ecbCiphertext d)
+            , testCase ("D" ++ i) (CCT.ecbDecrypt ctx (ecbCiphertext d) @?= ecbPlaintext d)
+            ]
+          where ctx = initCipher (Key cipher (ecbKey d))
+               
+testStreamKATs :: CCT.StreamCipher cipher => [KAT_Stream] -> cipher -> Test
+testStreamKATs kats cipher = testGroup "KAT" $ maybeGroup makeStreamTest "Stream" kats
+  where makeStreamTest i d =
+            [ testCase ("E" ++ i) (fst (CCT.streamCombine ctx (streamPlaintext d)) @?= streamCiphertext d)
+            , testCase ("D" ++ i) (fst (CCT.streamCombine ctx (streamCiphertext d)) @?= streamPlaintext d)
+            ]
+          where ctx = initCipher (Key cipher (streamKey d))
+
+maybeGroup :: (String -> t -> [Test]) -> TestName -> [t] -> [Test]
+maybeGroup mkTest groupName l
+    | null l    = []
+    | otherwise = [testGroup groupName (concatMap (\(i, d) -> mkTest (show i) d) $ zip [0..] l)]

--- a/src/Tests/Ciphers/PropertyTests.hs
+++ b/src/Tests/Ciphers/PropertyTests.hs
@@ -1,0 +1,28 @@
+module Ciphers.PropertyTests
+	( testBlockCipher
+	, testStreamCipher
+	) where
+
+-- source: crypto-cipher-tests
+
+import Test.Framework (Test, testGroup)
+
+import Crypto.Cipher.Types
+
+import Ciphers.KAT
+import Ciphers.TestModes
+import KAT.Utils
+
+-- | Return tests for a specific blockcipher and a list of KATs
+testBlockCipher :: BlockCipher a => KATs -> a -> Test
+testBlockCipher kats cipher = testGroup (cipherName cipher)
+    (  (if kats == defaultKATs  then [] else [testKATs kats cipher])
+    ++ testModes cipher
+    )
+
+-- | Return tests for a specific streamcipher and a list of KATs
+testStreamCipher :: StreamCipher a => [KAT_Stream] -> a -> Test
+testStreamCipher kats cipher = testGroup (cipherName cipher)
+    (  (if kats == defaultStreamKATs then [] else [testStreamKATs kats cipher])
+    ++ testStream cipher
+    )

--- a/src/Tests/Ciphers/TestModes.hs
+++ b/src/Tests/Ciphers/TestModes.hs
@@ -1,0 +1,192 @@
+
+module Ciphers.TestModes
+	( testModes
+	, testStream
+	) where
+
+-- source: crypto-cipher-tests
+
+import Test.Framework (Test, testGroup)
+import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.QuickCheck
+
+import Control.Monad (liftM)
+import Crypto.Cipher.Types as CCT
+import Crypto.Error
+import qualified Data.ByteString as B
+
+import Ciphers.Utils
+import KAT.Utils
+
+-- | a ECB unit test
+data ECBUnit a = ECBUnit B.ByteString a B.ByteString
+    deriving (Eq)
+
+instance Show (ECBUnit a) where
+    show (ECBUnit k _ b) = "ECB(key=" ++ show k ++ ",input=" ++ show b ++ ")"
+
+-- | a CBC unit test
+data CBCUnit a = CBCUnit B.ByteString a (IV a) B.ByteString
+    deriving (Eq)
+
+instance (CCT.BlockCipher a) => Show (CBCUnit a) where
+    show (CBCUnit k _ iv b) = "CBC(key=" ++ show k ++ ",iv=" ++ show (convertToShowable iv) ++ ",input=" ++ show b ++ ")"
+
+-- | a CFB unit test
+data CFBUnit a = CFBUnit B.ByteString a (IV a) B.ByteString
+    deriving (Eq)
+
+instance (CCT.BlockCipher a) => Show (CFBUnit a) where
+    show (CFBUnit k _ iv b) = "CFB(key=" ++ show k ++ ",iv=" ++ show (convertToShowable iv) ++ ",input=" ++ show b ++ ")"
+
+-- | a CTR unit test
+data CTRUnit a = CTRUnit B.ByteString a (IV a) B.ByteString
+    deriving (Eq)
+
+instance (CCT.BlockCipher a) => Show (CTRUnit a) where
+    show (CTRUnit k _ iv b) = "CTR(key=" ++ show k ++ ",iv=" ++ show (convertToShowable iv) ++ ",input=" ++ show b ++ ")"
+
+-- | a AEAD unit test
+data AEADUnit a = AEADUnit B.ByteString a (IV a) B.ByteString B.ByteString
+    deriving (Eq)
+
+instance (CCT.BlockCipher a) => Show (AEADUnit a) where
+    show (AEADUnit k _ iv aad b) = "AEAD(key=" ++ show k ++ ",iv=" ++ show (convertToShowable iv) ++ ",aad=" ++ show aad ++ ",input=" ++ show b ++ ")"
+
+-- | a Stream unit test
+data StreamUnit a = StreamUnit B.ByteString a B.ByteString
+    deriving (Eq)
+
+instance Show (StreamUnit a) where
+    show (StreamUnit k _ b) = "Stream(key=" ++ show k ++ ",input=" ++ show b ++ ")"
+
+getKey :: Key a b -> b
+getKey (Key _ b) = b
+
+genPlaintextBlocks :: CCT.BlockCipher cipher => Gen cipher -> Gen B.ByteString
+genPlaintextBlocks c = do
+            c' <- c
+            blocks <- choose (1,128)
+            genBlockCipherInput c' blocks
+
+genPlaintext :: CCT.Cipher cipher => Gen cipher -> Gen B.ByteString
+genPlaintext c = do
+            c' <- c
+            blocks <- choose (1,324)
+            genUnalignedBlockCipherInput c' blocks
+
+instance CCT.BlockCipher a => Arbitrary (ECBUnit a) where
+    arbitrary = let
+        k = genTypedKey undefined
+        c = liftM initCipher k
+        p = genPlaintextBlocks c
+        in ECBUnit <$> (liftM getKey k) <*> c <*> p
+
+instance CCT.BlockCipher a => Arbitrary (CBCUnit a) where
+    arbitrary = let
+        k = genTypedKey undefined
+        c = liftM initCipher k
+        iv = c >>= genIV
+        p = genPlaintextBlocks c
+        in CBCUnit <$> (liftM getKey k) <*> c <*> iv <*> p
+
+instance CCT.BlockCipher a => Arbitrary (CFBUnit a) where
+    arbitrary = let
+        k = genTypedKey undefined
+        c = liftM initCipher k
+        iv = c >>= genIV
+        p = genPlaintextBlocks c
+        in CFBUnit <$> (liftM getKey k) <*> c <*> iv <*> p
+
+instance CCT.BlockCipher a => Arbitrary (CTRUnit a) where
+    arbitrary = let
+        k = genTypedKey undefined
+        c = liftM initCipher k
+        iv = c >>= genIV
+        p = genPlaintext c
+        in CTRUnit <$> (liftM getKey k) <*> c <*> iv <*> p
+
+instance CCT.BlockCipher a => Arbitrary (AEADUnit a) where
+    arbitrary = let
+        k = genTypedKey undefined
+        c = liftM initCipher k
+        iv = c >>= genIV
+        aad = genPlaintext c
+        p = genPlaintext c
+        in AEADUnit <$> (liftM getKey k) <*> c <*> iv <*> aad <*> p
+
+instance CCT.StreamCipher a => Arbitrary (StreamUnit a) where
+    arbitrary = let
+        k = genTypedKey undefined
+        c = liftM initCipher k
+        p = genPlaintext c
+        in StreamUnit <$> (liftM getKey k) <*> c <*> p
+
+-- | Test a generic block cipher for properties
+-- related to block cipher modes.
+testModes :: CCT.BlockCipher a => a -> [Test]
+testModes cipher =
+    [ testGroup "decrypt.encrypt==id"
+        (testBlockCipherBasic cipher ++ testBlockCipherModes cipher ++ testBlockCipherAEAD cipher)
+    ]
+
+testBlockCipherBasic :: CCT.BlockCipher a => a -> [Test]
+testBlockCipherBasic cipher = [ testProperty "ECB" ecbProp ]
+  where ecbProp = toTests cipher
+        toTests :: CCT.BlockCipher a => a -> ECBUnit a -> Bool
+        toTests _ = testProperty_ECB
+        testProperty_ECB (ECBUnit _ ctx plaintext) =
+            plaintext `assertEq` CCT.ecbDecrypt ctx (CCT.ecbEncrypt ctx plaintext)
+
+testBlockCipherModes :: CCT.BlockCipher a => a -> [Test]
+testBlockCipherModes cipher =
+    [ testProperty "CBC" cbcProp
+    , testProperty "CFB" cfbProp
+    , testProperty "CTR" ctrProp
+    ]
+  where (cbcProp,cfbProp,ctrProp) = toTests cipher
+        toTests :: CCT.BlockCipher a
+                => a
+                -> ((CBCUnit a -> Bool), (CFBUnit a -> Bool), (CTRUnit a -> Bool))
+        toTests _ = (testProperty_CBC
+                    ,testProperty_CFB
+                    ,testProperty_CTR
+                    )
+        testProperty_CBC (CBCUnit _ ctx testIV plaintext) =
+            plaintext `assertEq` CCT.cbcDecrypt ctx testIV (CCT.cbcEncrypt ctx testIV plaintext)
+
+        testProperty_CFB (CFBUnit _ ctx testIV plaintext) =
+            plaintext `assertEq` CCT.cfbDecrypt ctx testIV (CCT.cfbEncrypt ctx testIV plaintext)
+
+        testProperty_CTR (CTRUnit _ ctx testIV plaintext) =
+            plaintext `assertEq` CCT.ctrCombine ctx testIV (CCT.ctrCombine ctx testIV plaintext)
+
+testBlockCipherAEAD :: CCT.BlockCipher a => a -> [Test]
+testBlockCipherAEAD cipher =
+    [ testProperty "OCB" (aeadProp CCT.AEAD_OCB)
+    , testProperty "CCM" (aeadProp (CCT.AEAD_CCM 0 CCM_M16 CCM_L2))
+    , testProperty "EAX" (aeadProp CCT.AEAD_EAX)
+    , testProperty "CWC" (aeadProp CCT.AEAD_CWC)
+    , testProperty "GCM" (aeadProp CCT.AEAD_GCM)
+    ]
+  where aeadProp = toTests cipher
+        toTests :: CCT.BlockCipher a => a -> (CCT.AEADMode -> AEADUnit a -> Bool)
+        toTests _ = testProperty_AEAD
+        testProperty_AEAD mode (AEADUnit _ ctx testIV aad plaintext) =
+            case aeadInit mode ctx testIV of
+                CryptoPassed iniAead ->
+                    let aead           = CCT.aeadAppendHeader iniAead aad
+                        (eText, aeadE) = CCT.aeadEncrypt aead plaintext
+                        (dText, aeadD) = CCT.aeadDecrypt aead eText
+                        eTag           = CCT.aeadFinalize aeadE (blockSize ctx)
+                        dTag           = CCT.aeadFinalize aeadD (blockSize ctx)
+                     in (plaintext `assertEq` dText) && (eTag `assertEq` dTag)
+                CryptoFailed _ -> True
+
+-- | Test stream mode
+testStream :: CCT.StreamCipher a => a -> [Test]
+testStream cipher = [testProperty "combine.combine==id" (testStreamUnit cipher)]
+  where testStreamUnit :: CCT.StreamCipher a => a -> (StreamUnit a -> Bool)
+        testStreamUnit _ (StreamUnit _ ctx plaintext) =
+            let cipherText = fst $ CCT.streamCombine ctx plaintext
+             in fst (CCT.streamCombine ctx cipherText) `assertEq` plaintext

--- a/src/Tests/Ciphers/Utils.hs
+++ b/src/Tests/Ciphers/Utils.hs
@@ -1,0 +1,71 @@
+
+module Ciphers.Utils
+	( Key(..)
+	, genByteString
+	, genKey'
+	, genKey
+	, genTypedKey
+	, runCryptoFailable
+	, genCipher
+	, genIV
+	, genUnalignedBlockCipherInput
+	, genBlockCipherInput
+	, initCipher
+	, convertToShowable
+	, assertEq
+	) where
+
+import Test.QuickCheck (Gen(..), elements, choose, vectorOf)
+
+import Control.Monad (liftM)
+import Crypto.Cipher.Types as CCT
+import Crypto.Error
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as B
+
+data Key c a = Key c a
+
+genByteString :: Int -> Gen B.ByteString
+genByteString len = liftM B.pack $ vectorOf len (choose (0,255))
+
+runMaybe :: (Monad m) => Maybe x -> m x
+runMaybe Nothing = error "got nothing"
+runMaybe (Just x) = return x
+
+genKey' :: CCT.KeySizeSpecifier -> Gen B.ByteString
+genKey' spec = case spec of
+	CCT.KeySizeRange bot top -> choose (bot, top) >>= genByteString
+	CCT.KeySizeEnum list     -> elements list >>= genByteString
+	CCT.KeySizeFixed f       -> genByteString f
+
+genKey :: CCT.Cipher c => c -> Gen (B.ByteString)
+genKey c = genKey' (CCT.cipherKeySize c)
+
+genTypedKey :: CCT.Cipher c => c -> Gen (Key c B.ByteString)
+genTypedKey c = liftM (Key c) $ genKey' (CCT.cipherKeySize c)
+
+runCryptoFailable :: CCT.Cipher c => CryptoFailable c -> c
+runCryptoFailable (CryptoFailed e) = error $ show e
+runCryptoFailable (CryptoPassed x) = x
+
+genCipher :: CCT.Cipher c => c -> Gen c
+genCipher c = liftM (runCryptoFailable . CCT.cipherInit) $ (genKey c)
+
+genIV :: CCT.BlockCipher c => c -> Gen (IV c)
+genIV c = genByteString (CCT.blockSize c) >>= runMaybe . CCT.makeIV
+
+genBlockCipherInput :: CCT.BlockCipher c => c -> Int -> Gen B.ByteString
+genBlockCipherInput c blocks = genByteString (CCT.blockSize c * blocks)
+
+genUnalignedBlockCipherInput :: CCT.Cipher c => c -> Int -> Gen B.ByteString
+genUnalignedBlockCipherInput c bytes = genByteString bytes
+
+initCipher :: (CCT.Cipher c, BA.ByteArray ba) => Key c ba -> c
+initCipher (Key _ k) = runCryptoFailable $ CCT.cipherInit k
+
+convertToShowable :: BA.ByteArrayAccess a => a -> BA.Bytes
+convertToShowable = BA.convert
+
+assertEq :: (BA.ByteArrayAccess a, BA.ByteArrayAccess b) => a -> b -> Bool
+assertEq b1 b2 | BA.eq b1 b2 = True
+               | otherwise = error ("b1: " ++ show (convertToShowable b1) ++ " b2: " ++ show (convertToShowable b2))

--- a/src/Tests/KAT/Utils.hs
+++ b/src/Tests/KAT/Utils.hs
@@ -1,13 +1,48 @@
 
 module KAT.Utils
-	( module Crypto.Cipher.Tests
+	( KATs(..)
+	, KAT_ECB(..)
+	, KAT_Stream(..)
+	, defaultKATs
+	, defaultStreamKATs
 	, concatKATs
 	) where
 
-import Crypto.Cipher.Tests
+import qualified Data.ByteString as B
+
+-- source: crypto-cipher-tests
+-- | all the KATs. use defaultKATs to prevent compilation error
+-- from future expansion of this data structure
+data KATs = KATs
+    { kat_ECB  :: [KAT_ECB]
+    } deriving (Show,Eq)
+
+-- | ECB KAT
+data KAT_ECB = KAT_ECB
+    { ecbKey        :: B.ByteString -- ^ Key
+    , ecbPlaintext  :: B.ByteString -- ^ Plaintext
+    , ecbCiphertext :: B.ByteString -- ^ Ciphertext
+    } deriving (Show,Eq)
+
+-- | KAT for Stream cipher
+data KAT_Stream = KAT_Stream
+    { streamKey        :: B.ByteString
+    , streamPlaintext  :: B.ByteString
+    , streamCiphertext :: B.ByteString
+    } deriving (Show,Eq)
+
+-- | the empty KATs
+defaultKATs :: KATs
+defaultKATs = KATs
+    { kat_ECB  = []
+    }
+
+-- | the empty KATs for stream
+defaultStreamKATs :: [KAT_Stream]
+defaultStreamKATs = []
 
 concatKATs :: [KATs] -> KATs
-concatKATs l = KATs (m kat_ECB) (m kat_CBC) (m kat_CFB) (m kat_CTR) (m kat_XTS) (m kat_AEAD)
+concatKATs l = KATs (m kat_ECB)
 	where
 	m :: (KATs -> [x]) -> [x]
 	m sel = concat $ map sel l


### PR DESCRIPTION
The `crypto-cipher-types` and `securemem` packages are outdated and unmaintained. `crypton` and `ram` are their respective replacements.

As the test dependency `crypto-cipher-tests` is also unmaintained and incompatible, its tests have been moved into this package and updated to be compatible.

For the most part, this PR replaces SecureMem with ScrubbedBytes which was already uses behind-the-scenes by SecureMem. The new APIs used by `crypton` don't rely on ByteString, instead opting for a parametric ByteArray from `ram`.
Another notable change is that AEADModeImpl is no longer a type class, so this had to be reimplemented.

Only downside is having to include the full crypton package when we really only depend on Crypto.Cipher.Types to provide a compatible interface. However, `hOpenPGP` - the only package that depends on `nettle` afaict - already depends on `crypton`, so this change actually reduces its footprint.

`hOpenPGP` will have to be adapted to this change as well. For this reason, a version bump to 0.4.0 can be justified.

Tested with `crypton` 1.1.4, `ram` 1.22.0 and 1.22.1, and GHC 9.6.6
Closes #7 